### PR TITLE
refactor ocfl.Spec

### DIFF
--- a/backend/cloud/cloud.go
+++ b/backend/cloud/cloud.go
@@ -345,9 +345,8 @@ func (fsys *FS) objectRootsList(ctx context.Context, sel ocfl.PathSelector, fn f
 			continue
 		}
 		keyBase := path.Base(item.Key)
-		// key is a declaration file?
-		var decl ocfl.Declaration
-		if ocfl.ParseDeclaration(keyBase, &decl); decl.Type == ocfl.DeclObject {
+		decl, err := ocfl.ParseNamaste(keyBase)
+		if err == nil && decl.Type == ocfl.DeclObject {
 			// new object declaration: apply fn to existing obj and reset
 			if obj != nil {
 				fsys.debugLog(ctx, "objectroots.complete",

--- a/backend/cloud/cloud.go
+++ b/backend/cloud/cloud.go
@@ -346,7 +346,7 @@ func (fsys *FS) objectRootsList(ctx context.Context, sel ocfl.PathSelector, fn f
 		}
 		keyBase := path.Base(item.Key)
 		decl, err := ocfl.ParseNamaste(keyBase)
-		if err == nil && decl.Type == ocfl.DeclObject {
+		if err == nil && decl.Type == ocfl.NamasteTypeObject {
 			// new object declaration: apply fn to existing obj and reset
 			if obj != nil {
 				fsys.debugLog(ctx, "objectroots.complete",

--- a/backend/cloud/cloud.go
+++ b/backend/cloud/cloud.go
@@ -303,7 +303,7 @@ func (fsys *FS) objectRootsWalkDirs(ctx context.Context, sel ocfl.PathSelector, 
 			return err
 		}
 		objRoot := ocfl.NewObjectRoot(fsys, name, entries)
-		if objRoot.HasDeclaration() {
+		if objRoot.HasNamaste() {
 			if err := fn(objRoot); err != nil {
 				return err
 			}
@@ -352,7 +352,7 @@ func (fsys *FS) objectRootsList(ctx context.Context, sel ocfl.PathSelector, fn f
 				fsys.debugLog(ctx, "objectroots.complete",
 					"dir", obj.Path,
 					"alg", obj.SidecarAlg,
-					"has_declaration", obj.HasDeclaration(),
+					"has_declaration", obj.HasNamaste(),
 					"has_inventory", obj.HasInventory(),
 					"has_sidecar", obj.HasSidecar(),
 					"versions", obj.VersionDirs,
@@ -365,7 +365,7 @@ func (fsys *FS) objectRootsList(ctx context.Context, sel ocfl.PathSelector, fn f
 				FS:    fsys,
 				Path:  keyDir,
 				Spec:  decl.Version,
-				Flags: ocfl.FoundDeclaration,
+				Flags: ocfl.HasNamaste,
 			}
 			continue
 		}
@@ -379,21 +379,21 @@ func (fsys *FS) objectRootsList(ctx context.Context, sel ocfl.PathSelector, fn f
 		if keyDir == obj.Path {
 			// inventory.json
 			if keyBase == "inventory.json" {
-				obj.Flags = obj.Flags | ocfl.FoundInventory
+				obj.Flags = obj.Flags | ocfl.HasInventory
 				continue
 			}
 			// sidecar
 			if strings.HasPrefix(keyBase, "inventory.json.") {
 				obj.SidecarAlg = strings.TrimPrefix(keyBase, "inventory.json.")
-				obj.Flags |= ocfl.FoundSidecar
+				obj.Flags |= ocfl.HasSidecar
 				continue
 			}
 
 		}
 		// directories in object root: versions and extensions
 		child, _, _ := strings.Cut(strings.TrimPrefix(item.Key, obj.Path+"/"), "/")
-		if child == "extensions" && (obj.Flags&ocfl.FoundExtensions) == 0 {
-			obj.Flags |= ocfl.FoundExtensions
+		if child == "extensions" && (obj.Flags&ocfl.HasExtensions) == 0 {
+			obj.Flags |= ocfl.HasExtensions
 			continue
 		}
 		var v ocfl.VNum

--- a/backend/cloud/cloud_test.go
+++ b/backend/cloud/cloud_test.go
@@ -416,7 +416,7 @@ func TestObjectRoots(t *testing.T) {
 		}
 		extFixture := "W013_unregistered_extension"
 		if strings.HasSuffix(obj.Path, extFixture) {
-			if obj.Flags&ocfl.FoundExtensions == 0 {
+			if obj.Flags&ocfl.HasExtensions == 0 {
 				t.Errorf(obj.Path, "should have extensions flag")
 			}
 		}

--- a/namaste.go
+++ b/namaste.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	DeclObject = "ocfl_object" // type string for OCFL Object declaration
-	DeclStore  = "ocfl"        // type string for OCFL Storage Root declaration
+	NamasteTypeObject = "ocfl_object" // type string for OCFL Object declaration
+	NamasteTypeStore  = "ocfl"        // type string for OCFL Storage Root declaration
 )
 
 var (

--- a/namaste.go
+++ b/namaste.go
@@ -76,7 +76,8 @@ func ParseDeclaration(name string, dec *Declaration) error {
 		return ErrDeclNotExist
 	}
 	dec.Type = m[1]
-	err := ParseSpec(m[2], &dec.Version)
+	var err error
+	dec.Version, err = ParseSpec(m[2])
 	if err != nil {
 		return ErrDeclNotExist
 	}

--- a/namaste.go
+++ b/namaste.go
@@ -17,80 +17,74 @@ const (
 )
 
 var (
-	ErrDeclNotExist = fmt.Errorf("missing declaration: %w", fs.ErrNotExist)
-	ErrDeclInvalid  = errors.New("invalid NAMASTE declaration contents")
-	ErrDeclMultiple = errors.New("multiple NAMASTE declarations found")
-	namasteRE       = regexp.MustCompile(`^0=([a-z_]+)_([0-9]+\.[0-9]+)$`)
+	ErrNoNamaste       = fmt.Errorf("missing NAMASTE declaration: %w", fs.ErrNotExist)
+	ErrNamasteInvalid  = errors.New("invalid NAMASTE declaration contents")
+	ErrNamasteMultiple = errors.New("multiple NAMASTE declarations found")
+	namasteRE          = regexp.MustCompile(`^0=([a-z_]+)_([0-9]+\.[0-9]+)$`)
 )
 
-// Declaration represents a NAMASTE Declaration
-type Declaration struct {
+// Namaste represents a NAMASTE declaration
+type Namaste struct {
 	Type    string
 	Version Spec
 }
 
-// FindDeclaration returns the declaration from a fs.DirEntry slice. An
+// FindNamaste returns the Namasted declaration from a fs.DirEntry slice. An
 // error is returned if the number of declarations is not one.
-func FindDeclaration(items []fs.DirEntry) (Declaration, error) {
-	var found []Declaration
+func FindNamaste(items []fs.DirEntry) (Namaste, error) {
+	var found []Namaste
 	for _, e := range items {
 		if !e.Type().IsRegular() {
 			continue
 		}
-		dec := Declaration{}
-		if err := ParseDeclaration(e.Name(), &dec); err != nil {
-			continue
+		if dec, err := ParseNamaste(e.Name()); err == nil {
+			found = append(found, dec)
 		}
-		found = append(found, dec)
 	}
 	switch len(found) {
 	case 0:
-		return Declaration{}, ErrDeclNotExist
+		return Namaste{}, ErrNoNamaste
 	case 1:
 		return found[0], nil
 	}
-	return Declaration{}, ErrDeclMultiple
+	return Namaste{}, ErrNamasteMultiple
 }
 
 // Name returns the filename for d (0=TYPE_VERSION) or an empty string if d is
 // empty
-func (d Declaration) Name() string {
-	if d.Type == "" || d.Version.Empty() {
+func (n Namaste) Name() string {
+	if n.Type == "" || n.Version.Empty() {
 		return ""
 	}
-	return "0=" + d.Type + `_` + d.Version.String()
+	return "0=" + n.Type + `_` + string(n.Version)
 }
 
-// Contents returns the file contents of the declaration or an empty string if d
-// is empty
-func (d Declaration) Contents() string {
-	if d.Type == "" || d.Version.Empty() {
+// Body returns the expected file contents of the namaste declaration
+func (n Namaste) Body() string {
+	if n.Type == "" || n.Version.Empty() {
 		return ""
 	}
-	return d.Type + `_` + d.Version.String() + "\n"
+	return n.Type + `_` + string(n.Version) + "\n"
 }
 
-func ParseDeclaration(name string, dec *Declaration) error {
+func ParseNamaste(name string) (Namaste, error) {
+	var d Namaste
 	m := namasteRE.FindStringSubmatch(name)
 	if len(m) != 3 {
-		return ErrDeclNotExist
+		return d, ErrNoNamaste
 	}
-	dec.Type = m[1]
-	var err error
-	dec.Version, err = ParseSpec(m[2])
-	if err != nil {
-		return ErrDeclNotExist
-	}
-	return nil
+	d.Type = m[1]
+	d.Version = Spec(m[2])
+	return d, nil
 }
 
-// ReadDeclaration validates a namaste declaration
-func ReadDeclaration(ctx context.Context, fsys FS, filePath string) error {
-	var d Declaration
-	if err := ParseDeclaration(path.Base(filePath), &d); err != nil {
+// ReadNamaste validates a namaste declaration
+func ReadNamaste(ctx context.Context, fsys FS, name string) error {
+	d, err := ParseNamaste(path.Base(name))
+	if err != nil {
 		return err
 	}
-	f, err := fsys.OpenFile(ctx, filePath)
+	f, err := fsys.OpenFile(ctx, name)
 	if err != nil {
 		return fmt.Errorf("opening declaration: %w", err)
 	}
@@ -99,14 +93,14 @@ func ReadDeclaration(ctx context.Context, fsys FS, filePath string) error {
 	if err != nil {
 		return fmt.Errorf("reading declaration: %w", err)
 	}
-	if string(decl) != d.Contents() {
-		return ErrDeclInvalid
+	if string(decl) != d.Body() {
+		return ErrNamasteInvalid
 	}
 	return nil
 }
 
-func WriteDeclaration(ctx context.Context, root WriteFS, dir string, d Declaration) error {
-	cont := strings.NewReader(d.Contents())
+func WriteDeclaration(ctx context.Context, root WriteFS, dir string, d Namaste) error {
+	cont := strings.NewReader(d.Body())
 	_, err := root.Write(ctx, path.Join(dir, d.Name()), cont)
 	if err != nil {
 		return fmt.Errorf(`writing declaration: %w`, err)

--- a/namaste_test.go
+++ b/namaste_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestParseName(t *testing.T) {
 	table := map[string]ocfl.Declaration{
-		`0=ocfl_1.0`: {`ocfl`, ocfl.Spec{1, 0}},
-		`0=oc_1.1`:   {`oc`, ocfl.Spec{1, 1}},
-		`1=ocfl_1.0`: {``, ocfl.Spec{}},
-		`0=AB_1`:     {``, ocfl.Spec{}},
+		`0=ocfl_1.0`: {`ocfl`, ocfl.Spec1_0},
+		`0=oc_1.1`:   {`oc`, ocfl.Spec1_1},
+		`1=ocfl_1.0`: {``, ocfl.Spec("")},
+		`0=AB_1`:     {``, ocfl.Spec("")},
 	}
 	for in, exp := range table {
 		t.Run(in, func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestWriteDeclaration(t *testing.T) {
 	is := is.New(t)
 	fsys := memfs.New()
 	ctx := context.Background()
-	v := ocfl.Spec{12, 1}
+	v := ocfl.Spec("12.1")
 	dec := &ocfl.Declaration{"ocfl", v}
 	err := ocfl.WriteDeclaration(ctx, fsys, ".", *dec)
 	is.NoErr(err)

--- a/namaste_test.go
+++ b/namaste_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestParseName(t *testing.T) {
-	table := map[string]ocfl.Declaration{
+	table := map[string]ocfl.Namaste{
 		`0=ocfl_1.0`: {`ocfl`, ocfl.Spec1_0},
 		`0=oc_1.1`:   {`oc`, ocfl.Spec1_1},
 		`1=ocfl_1.0`: {``, ocfl.Spec("")},
@@ -20,8 +20,7 @@ func TestParseName(t *testing.T) {
 	for in, exp := range table {
 		t.Run(in, func(t *testing.T) {
 			is := is.New(t)
-			var d ocfl.Declaration
-			err := ocfl.ParseDeclaration(in, &d)
+			d, err := ocfl.ParseNamaste(in)
 			if exp.Type != "" {
 				is.NoErr(err)
 				is.Equal(d, exp)
@@ -43,11 +42,11 @@ func TestValidate(t *testing.T) {
 		"1=hot_tub_12.1": &fstest.MapFile{
 			Data: []byte("hot_tub_12.1\n")},
 	}
-	err := ocfl.ReadDeclaration(context.Background(), ocfl.NewFS(fsys), "0=hot_tub_12.1")
+	err := ocfl.ReadNamaste(context.Background(), ocfl.NewFS(fsys), "0=hot_tub_12.1")
 	is.NoErr(err)
-	err = ocfl.ReadDeclaration(context.Background(), ocfl.NewFS(fsys), "0=hot_bath_12.1")
+	err = ocfl.ReadNamaste(context.Background(), ocfl.NewFS(fsys), "0=hot_bath_12.1")
 	is.True(err != nil)
-	err = ocfl.ReadDeclaration(context.Background(), ocfl.NewFS(fsys), "1=hot_tub_12.1")
+	err = ocfl.ReadNamaste(context.Background(), ocfl.NewFS(fsys), "1=hot_tub_12.1")
 	is.True(err != nil)
 }
 
@@ -56,15 +55,15 @@ func TestWriteDeclaration(t *testing.T) {
 	fsys := memfs.New()
 	ctx := context.Background()
 	v := ocfl.Spec("12.1")
-	dec := &ocfl.Declaration{"ocfl", v}
+	dec := &ocfl.Namaste{"ocfl", v}
 	err := ocfl.WriteDeclaration(ctx, fsys, ".", *dec)
 	is.NoErr(err)
 	inf, err := fsys.ReadDir(ctx, ".")
 	is.NoErr(err)
-	out, err := ocfl.FindDeclaration(inf)
+	out, err := ocfl.FindNamaste(inf)
 	is.NoErr(err)
 	is.True(out.Type == "ocfl")
 	is.True(out.Version == v)
-	err = ocfl.ReadDeclaration(ctx, fsys, dec.Name())
+	err = ocfl.ReadNamaste(ctx, fsys, dec.Name())
 	is.NoErr(err)
 }

--- a/objectroot.go
+++ b/objectroot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/srerickson/ocfl-go/internal/walkdirs"
@@ -16,15 +17,16 @@ const (
 )
 
 var (
-	ErrObjectExists = fmt.Errorf("existing OCFL object declaration: %w", fs.ErrExist)
+	ErrObjectNotFound = fmt.Errorf("missing object declaration: %w", ErrNoNamaste)
+	ErrObjectExists   = fmt.Errorf("existing OCFL object declaration: %w", fs.ErrExist)
 )
 
 // GetObjectRoot reads the contents of directory dir in fsys, confirms that an
 // OCFL Object declaration is present, and returns a new ObjectRoot reference
-// based on the directory contents. If the directory cannot be ready or a
+// based on the directory contents. If the directory cannot be read or a
 // declaration is not found, ErrObjectNotFound is returned. Note, the object
 // declaration is not read or fully validated. The returned ObjectRoot will have
-// the FoundDeclaration flag set, but other flags expected for a complete object
+// the FoundNamaste flag set, but other flags expected for a complete object
 // root may not be set (e.g., if the inventory is missing).
 func GetObjectRoot(ctx context.Context, fsys FS, dir string) (*ObjectRoot, error) {
 	entries, err := fsys.ReadDir(ctx, dir)
@@ -32,8 +34,8 @@ func GetObjectRoot(ctx context.Context, fsys FS, dir string) (*ObjectRoot, error
 		return nil, err
 	}
 	obj := NewObjectRoot(fsys, dir, entries)
-	if !obj.HasDeclaration() {
-		return nil, ErrNoNamaste
+	if !obj.HasNamaste() {
+		return nil, fmt.Errorf("missing object declaration: %w", ErrNoNamaste)
 	}
 	return obj, nil
 }
@@ -51,7 +53,7 @@ func NewObjectRoot(fsys FS, dir string, entries []fs.DirEntry) *ObjectRoot {
 		name := e.Name()
 		if e.IsDir() {
 			if name == ExtensionsDir {
-				obj.Flags |= FoundExtensions
+				obj.Flags |= HasExtensions
 				continue
 			}
 			var v VNum
@@ -62,19 +64,19 @@ func NewObjectRoot(fsys FS, dir string, entries []fs.DirEntry) *ObjectRoot {
 		}
 		if e.Type().IsRegular() { // regular file
 			if name == inventoryFile {
-				obj.Flags |= FoundInventory
+				obj.Flags |= HasInventory
 				continue
 			}
 			scPrefix := inventoryFile + "."
 			if strings.HasPrefix(name, scPrefix) {
 				obj.SidecarAlg = strings.TrimPrefix(name, scPrefix)
-				obj.Flags |= FoundSidecar
+				obj.Flags |= HasSidecar
 				continue
 			}
 			if decl, err := ParseNamaste(name); err == nil {
-				if decl.Type == NamasteTypeObject && !obj.HasDeclaration() {
+				if decl.Type == NamasteTypeObject && !obj.HasNamaste() {
 					obj.Spec = decl.Version
-					obj.Flags |= FoundDeclaration
+					obj.Flags |= HasNamaste
 					continue
 				}
 			}
@@ -102,53 +104,48 @@ type ObjectRoot struct {
 type ObjectRootFlag int
 
 const (
-	// FoundDeclaration indicates that an ObjectRoot has been initialized
+	// HasNamaste indicates that an ObjectRoot has been initialized
 	// and an object declaration file is confirmed to exist in the object's root
 	// directory
-	FoundDeclaration ObjectRootFlag = 1 << iota
-	// FoundInventory indicates that an ObjectRoot includes an "inventory.json"
+	HasNamaste ObjectRootFlag = 1 << iota
+	// HasInventory indicates that an ObjectRoot includes an "inventory.json"
 	// file
-	FoundInventory
-	// FoundSidecar indicates that an ObjectRoot includes an "inventory.json.*"
+	HasInventory
+	// HasSidecar indicates that an ObjectRoot includes an "inventory.json.*"
 	// file (the inventory sidecar).
-	FoundSidecar
-	// FoundExtensions indicates that an ObjectRoot includes a directory
+	HasSidecar
+	// HasExtensions indicates that an ObjectRoot includes a directory
 	// named "extensions"
-	FoundExtensions
+	HasExtensions
 )
 
-// ValidateDeclaration reads and validates the contents of the OCFL object
+// ValidateNamaste reads and validates the contents of the OCFL object
 // declaration in the object root.
-func (obj ObjectRoot) ValidateDeclaration(ctx context.Context) error {
-	if !obj.HasDeclaration() {
+func (obj ObjectRoot) ValidateNamaste(ctx context.Context) error {
+	if !obj.HasNamaste() {
 		return ErrNoNamaste
 	}
 	pth := path.Join(obj.Path, Namaste{Type: NamasteTypeObject, Version: obj.Spec}.Name())
 	return ReadNamaste(ctx, obj.FS, pth)
 }
 
-// HasDeclaration returns true if the object's FoundDeclaration flag is set
-func (obj ObjectRoot) HasDeclaration() bool {
-	return obj.Flags&FoundDeclaration > 0
+// HasNamaste returns true if the object's FoundDeclaration flag is set
+func (obj ObjectRoot) HasNamaste() bool {
+	return obj.Flags&HasNamaste > 0
 }
 
 // HasInventory returns true if the object's FoundInventory flag is set
 func (obj ObjectRoot) HasInventory() bool {
-	return obj.Flags&FoundInventory > 0
+	return obj.Flags&HasInventory > 0
 }
 
 // HasSidecar returns true if the object's FoundSidecar flag is set
 func (obj ObjectRoot) HasSidecar() bool {
-	return obj.Flags&FoundSidecar > 0
+	return obj.Flags&HasSidecar > 0
 }
 
 func (obj ObjectRoot) HasVersionDir(dir VNum) bool {
-	for _, v := range obj.VersionDirs {
-		if v == dir {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(obj.VersionDirs, dir)
 }
 
 // ObjectRootIterator is used to iterate over object roots
@@ -173,7 +170,7 @@ func ObjectRoots(ctx context.Context, fsys FS, sel PathSelector, fn func(*Object
 			return err
 		}
 		objRoot := NewObjectRoot(fsys, name, entries)
-		if objRoot.HasDeclaration() {
+		if objRoot.HasNamaste() {
 			if err := fn(objRoot); err != nil {
 				return err
 			}

--- a/objectroot.go
+++ b/objectroot.go
@@ -72,7 +72,7 @@ func NewObjectRoot(fsys FS, dir string, entries []fs.DirEntry) *ObjectRoot {
 				continue
 			}
 			if decl, err := ParseNamaste(name); err == nil {
-				if decl.Type == DeclObject && !obj.HasDeclaration() {
+				if decl.Type == NamasteTypeObject && !obj.HasDeclaration() {
 					obj.Spec = decl.Version
 					obj.Flags |= FoundDeclaration
 					continue
@@ -123,7 +123,7 @@ func (obj ObjectRoot) ValidateDeclaration(ctx context.Context) error {
 	if !obj.HasDeclaration() {
 		return ErrNoNamaste
 	}
-	pth := path.Join(obj.Path, Namaste{Type: DeclObject, Version: obj.Spec}.Name())
+	pth := path.Join(obj.Path, Namaste{Type: NamasteTypeObject, Version: obj.Spec}.Name())
 	return ReadNamaste(ctx, obj.FS, pth)
 }
 

--- a/objectroot.go
+++ b/objectroot.go
@@ -33,7 +33,7 @@ func GetObjectRoot(ctx context.Context, fsys FS, dir string) (*ObjectRoot, error
 	}
 	obj := NewObjectRoot(fsys, dir, entries)
 	if !obj.HasDeclaration() {
-		return nil, ErrDeclNotExist
+		return nil, ErrNoNamaste
 	}
 	return obj, nil
 }
@@ -71,8 +71,7 @@ func NewObjectRoot(fsys FS, dir string, entries []fs.DirEntry) *ObjectRoot {
 				obj.Flags |= FoundSidecar
 				continue
 			}
-			var decl Declaration
-			if err := ParseDeclaration(name, &decl); err == nil {
+			if decl, err := ParseNamaste(name); err == nil {
 				if decl.Type == DeclObject && !obj.HasDeclaration() {
 					obj.Spec = decl.Version
 					obj.Flags |= FoundDeclaration
@@ -122,10 +121,10 @@ const (
 // declaration in the object root.
 func (obj ObjectRoot) ValidateDeclaration(ctx context.Context) error {
 	if !obj.HasDeclaration() {
-		return ErrDeclNotExist
+		return ErrNoNamaste
 	}
-	pth := path.Join(obj.Path, Declaration{Type: DeclObject, Version: obj.Spec}.Name())
-	return ReadDeclaration(ctx, obj.FS, pth)
+	pth := path.Join(obj.Path, Namaste{Type: DeclObject, Version: obj.Spec}.Name())
+	return ReadNamaste(ctx, obj.FS, pth)
 }
 
 // HasDeclaration returns true if the object's FoundDeclaration flag is set

--- a/objectroot_test.go
+++ b/objectroot_test.go
@@ -51,7 +51,7 @@ func TestObjectRoots(t *testing.T) {
 				}
 				extFixture := "W013_unregistered_extension"
 				if strings.HasSuffix(obj.Path, extFixture) {
-					if obj.Flags&ocfl.FoundExtensions == 0 {
+					if obj.Flags&ocfl.HasExtensions == 0 {
 						t.Errorf(obj.Path, "should have extensions flag")
 					}
 				}

--- a/ocfl.go
+++ b/ocfl.go
@@ -15,9 +15,6 @@ const (
 )
 
 var (
-	Spec1_0 = Spec{1, 0}
-	Spec1_1 = Spec{1, 1}
-
 	digestConcurrency atomic.Int32
 	commitConcurrency atomic.Int32
 )

--- a/ocflv1/codes/codes.go
+++ b/ocflv1/codes/codes.go
@@ -10,11 +10,11 @@ import (
 // E001: The OCFL Object Root must not contain files or directories other than those specified in the following sections.
 var E001 = validation.NewCode("E001",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The OCFL Object Root must not contain files or directories other than those specified in the following sections.",
 			URL:         "https://ocfl.io/1.0/spec/#E001",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The OCFL Object Root must not contain files or directories other than those specified in the following sections.",
 			URL:         "https://ocfl.io/1.1/spec/#E001",
 		},
@@ -23,11 +23,11 @@ var E001 = validation.NewCode("E001",
 // E002: The version declaration must be formatted according to the NAMASTE specification.
 var E002 = validation.NewCode("E002",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The version declaration must be formatted according to the NAMASTE specification.",
 			URL:         "https://ocfl.io/1.0/spec/#E002",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The version declaration must be formatted according to the NAMASTE specification.",
 			URL:         "https://ocfl.io/1.1/spec/#E002",
 		},
@@ -36,11 +36,11 @@ var E002 = validation.NewCode("E002",
 // E003: [The version declaration] must be a file in the base directory of the OCFL Object Root giving the OCFL version in the filename.
 var E003 = validation.NewCode("E003",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[The version declaration] must be a file in the base directory of the OCFL Object Root giving the OCFL version in the filename.",
 			URL:         "https://ocfl.io/1.0/spec/#E003",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "There must be exactly one version declaration file in the base directory of the OCFL Object Root giving the OCFL version in the filename.",
 			URL:         "https://ocfl.io/1.1/spec/#E003",
 		},
@@ -49,11 +49,11 @@ var E003 = validation.NewCode("E003",
 // E004: The [version declaration] filename MUST conform to the pattern T=dvalue, where T must be 0, and dvalue must be ocfl_object_, followed by the OCFL specification ocfl.Number.
 var E004 = validation.NewCode("E004",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The [version declaration] filename MUST conform to the pattern T=dvalue, where T must be 0, and dvalue must be ocfl_object_, followed by the OCFL specification ocfl.Number.",
 			URL:         "https://ocfl.io/1.0/spec/#E004",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The [version declaration] filename MUST conform to the pattern T=dvalue, where T must be 0, and dvalue must be ocfl_object_, followed by the OCFL specification version number.",
 			URL:         "https://ocfl.io/1.1/spec/#E004",
 		},
@@ -62,11 +62,11 @@ var E004 = validation.NewCode("E004",
 // E005: The [version declaration] filename must conform to the pattern T=dvalue, where T MUST be 0, and dvalue must be ocfl_object_, followed by the OCFL specification ocfl.Number.
 var E005 = validation.NewCode("E005",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The [version declaration] filename must conform to the pattern T=dvalue, where T MUST be 0, and dvalue must be ocfl_object_, followed by the OCFL specification ocfl.Number.",
 			URL:         "https://ocfl.io/1.0/spec/#E005",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The [version declaration] filename must conform to the pattern T=dvalue, where T MUST be 0, and dvalue must be ocfl_object_, followed by the OCFL specification version number.",
 			URL:         "https://ocfl.io/1.1/spec/#E005",
 		},
@@ -75,11 +75,11 @@ var E005 = validation.NewCode("E005",
 // E006: The [version declaration] filename must conform to the pattern T=dvalue, where T must be 0, and dvalue MUST be ocfl_object_, followed by the OCFL specification ocfl.Number.
 var E006 = validation.NewCode("E006",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The [version declaration] filename must conform to the pattern T=dvalue, where T must be 0, and dvalue MUST be ocfl_object_, followed by the OCFL specification ocfl.Number.",
 			URL:         "https://ocfl.io/1.0/spec/#E006",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The [version declaration] filename must conform to the pattern T=dvalue, where T must be 0, and dvalue MUST be ocfl_object_, followed by the OCFL specification version number.",
 			URL:         "https://ocfl.io/1.1/spec/#E006",
 		},
@@ -88,11 +88,11 @@ var E006 = validation.NewCode("E006",
 // E007: The text contents of the [version declaration] file must be the same as dvalue, followed by a newline (\n).
 var E007 = validation.NewCode("E007",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The text contents of the [version declaration] file must be the same as dvalue, followed by a newline (\n).",
 			URL:         "https://ocfl.io/1.0/spec/#E007",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The text contents of the [version declaration] file must be the same as dvalue, followed by a newline (\n).",
 			URL:         "https://ocfl.io/1.1/spec/#E007",
 		},
@@ -101,11 +101,11 @@ var E007 = validation.NewCode("E007",
 // E008: OCFL Object content must be stored as a sequence of one or more versions.
 var E008 = validation.NewCode("E008",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "OCFL Object content must be stored as a sequence of one or more versions.",
 			URL:         "https://ocfl.io/1.0/spec/#E008",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "OCFL Object content must be stored as a sequence of one or more versions.",
 			URL:         "https://ocfl.io/1.1/spec/#E008",
 		},
@@ -114,11 +114,11 @@ var E008 = validation.NewCode("E008",
 // E009: The ocfl.Number sequence MUST start at 1 and must be continuous without missing integers.
 var E009 = validation.NewCode("E009",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The ocfl.Number sequence MUST start at 1 and must be continuous without missing integers.",
 			URL:         "https://ocfl.io/1.0/spec/#E009",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The version number sequence MUST start at 1 and must be continuous without missing integers.",
 			URL:         "https://ocfl.io/1.1/spec/#E009",
 		},
@@ -127,11 +127,11 @@ var E009 = validation.NewCode("E009",
 // E010: The ocfl.Number sequence must start at 1 and MUST be continuous without missing integers.
 var E010 = validation.NewCode("E010",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The ocfl.Number sequence must start at 1 and MUST be continuous without missing integers.",
 			URL:         "https://ocfl.io/1.0/spec/#E010",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The version number sequence must start at 1 and MUST be continuous without missing integers.",
 			URL:         "https://ocfl.io/1.1/spec/#E010",
 		},
@@ -140,11 +140,11 @@ var E010 = validation.NewCode("E010",
 // E011: If zero-padded version directory numbers are used then they must start with the prefix v and then a zero.
 var E011 = validation.NewCode("E011",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "If zero-padded version directory numbers are used then they must start with the prefix v and then a zero.",
 			URL:         "https://ocfl.io/1.0/spec/#E011",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "If zero-padded version directory numbers are used then they must start with the prefix v and then a zero.",
 			URL:         "https://ocfl.io/1.1/spec/#E011",
 		},
@@ -153,11 +153,11 @@ var E011 = validation.NewCode("E011",
 // E012: All version directories of an object must use the same naming convention: either a non-padded version directory number, or a zero-padded version directory number of consistent length.
 var E012 = validation.NewCode("E012",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "All version directories of an object must use the same naming convention: either a non-padded version directory number, or a zero-padded version directory number of consistent length.",
 			URL:         "https://ocfl.io/1.0/spec/#E012",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "All version directories of an object must use the same naming convention: either a non-padded version directory number, or a zero-padded version directory number of consistent length.",
 			URL:         "https://ocfl.io/1.1/spec/#E012",
 		},
@@ -166,11 +166,11 @@ var E012 = validation.NewCode("E012",
 // E013: Operations that add a new version to an object must follow the version directory naming convention established by earlier versions.
 var E013 = validation.NewCode("E013",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Operations that add a new version to an object must follow the version directory naming convention established by earlier versions.",
 			URL:         "https://ocfl.io/1.0/spec/#E013",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Operations that add a new version to an object must follow the version directory naming convention established by earlier versions.",
 			URL:         "https://ocfl.io/1.1/spec/#E013",
 		},
@@ -179,11 +179,11 @@ var E013 = validation.NewCode("E013",
 // E014: In all cases, references to files inside version directories from inventory files must use the actual version directory names.
 var E014 = validation.NewCode("E014",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "In all cases, references to files inside version directories from inventory files must use the actual version directory names.",
 			URL:         "https://ocfl.io/1.0/spec/#E014",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In all cases, references to files inside version directories from inventory files must use the actual version directory names.",
 			URL:         "https://ocfl.io/1.1/spec/#E014",
 		},
@@ -192,11 +192,11 @@ var E014 = validation.NewCode("E014",
 // E015: There must be no other files as children of a version directory, other than an inventory file and a inventory digest.
 var E015 = validation.NewCode("E015",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "There must be no other files as children of a version directory, other than an inventory file and a inventory digest.",
 			URL:         "https://ocfl.io/1.0/spec/#E015",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "There must be no other files as children of a version directory, other than an inventory file and a inventory digest.",
 			URL:         "https://ocfl.io/1.1/spec/#E015",
 		},
@@ -205,11 +205,11 @@ var E015 = validation.NewCode("E015",
 // E016: Version directories must contain a designated content sub-directory if the version contains files to be preserved, and should not contain this sub-directory otherwise.
 var E016 = validation.NewCode("E016",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Version directories must contain a designated content sub-directory if the version contains files to be preserved, and should not contain this sub-directory otherwise.",
 			URL:         "https://ocfl.io/1.0/spec/#E016",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Version directories must contain a designated content sub-directory if the version contains files to be preserved, and should not contain this sub-directory otherwise.",
 			URL:         "https://ocfl.io/1.1/spec/#E016",
 		},
@@ -218,11 +218,11 @@ var E016 = validation.NewCode("E016",
 // E017: The contentDirectory value MUST NOT contain the forward slash (/) path separator and must not be either one or two periods (. or ..).
 var E017 = validation.NewCode("E017",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The contentDirectory value MUST NOT contain the forward slash (/) path separator and must not be either one or two periods (. or ..).",
 			URL:         "https://ocfl.io/1.0/spec/#E017",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The contentDirectory value MUST NOT contain the forward slash (/) path separator and must not be either one or two periods (. or ..).",
 			URL:         "https://ocfl.io/1.1/spec/#E017",
 		},
@@ -231,11 +231,11 @@ var E017 = validation.NewCode("E017",
 // E018: The contentDirectory value must not contain the forward slash (/) path separator and MUST NOT be either one or two periods (. or ..).
 var E018 = validation.NewCode("E018",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The contentDirectory value must not contain the forward slash (/) path separator and MUST NOT be either one or two periods (. or ..).",
 			URL:         "https://ocfl.io/1.0/spec/#E018",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The contentDirectory value must not contain the forward slash (/) path separator and MUST NOT be either one or two periods (. or ..).",
 			URL:         "https://ocfl.io/1.1/spec/#E018",
 		},
@@ -244,11 +244,11 @@ var E018 = validation.NewCode("E018",
 // E019: If the key contentDirectory is set, it MUST be set in the first version of the object and must not change between versions of the same object.
 var E019 = validation.NewCode("E019",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "If the key contentDirectory is set, it MUST be set in the first version of the object and must not change between versions of the same object.",
 			URL:         "https://ocfl.io/1.0/spec/#E019",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "If the key contentDirectory is set, it MUST be set in the first version of the object and must not change between versions of the same object.",
 			URL:         "https://ocfl.io/1.1/spec/#E019",
 		},
@@ -257,11 +257,11 @@ var E019 = validation.NewCode("E019",
 // E020: If the key contentDirectory is set, it must be set in the first version of the object and MUST NOT change between versions of the same object.
 var E020 = validation.NewCode("E020",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "If the key contentDirectory is set, it must be set in the first version of the object and MUST NOT change between versions of the same object.",
 			URL:         "https://ocfl.io/1.0/spec/#E020",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "If the key contentDirectory is set, it must be set in the first version of the object and MUST NOT change between versions of the same object.",
 			URL:         "https://ocfl.io/1.1/spec/#E020",
 		},
@@ -270,11 +270,11 @@ var E020 = validation.NewCode("E020",
 // E021: If the key contentDirectory is not present in the inventory file then the name of the designated content sub-directory must be content.
 var E021 = validation.NewCode("E021",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "If the key contentDirectory is not present in the inventory file then the name of the designated content sub-directory must be content.",
 			URL:         "https://ocfl.io/1.0/spec/#E021",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "If the key contentDirectory is not present in the inventory file then the name of the designated content sub-directory must be content.",
 			URL:         "https://ocfl.io/1.1/spec/#E021",
 		},
@@ -283,11 +283,11 @@ var E021 = validation.NewCode("E021",
 // E022: OCFL-compliant tools (including any validators) must ignore all directories in the object version directory except for the designated content directory.
 var E022 = validation.NewCode("E022",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "OCFL-compliant tools (including any validators) must ignore all directories in the object version directory except for the designated content directory.",
 			URL:         "https://ocfl.io/1.0/spec/#E022",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "OCFL-compliant tools (including any validators) must ignore all directories in the object version directory except for the designated content directory.",
 			URL:         "https://ocfl.io/1.1/spec/#E022",
 		},
@@ -296,11 +296,11 @@ var E022 = validation.NewCode("E022",
 // E023: Every file within a version's content directory must be referenced in the manifest section of the inventory.
 var E023 = validation.NewCode("E023",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Every file within a version's content directory must be referenced in the manifest section of the inventory.",
 			URL:         "https://ocfl.io/1.0/spec/#E023",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Every file within a version's content directory must be referenced in the manifest section of the inventory.",
 			URL:         "https://ocfl.io/1.1/spec/#E023",
 		},
@@ -309,11 +309,11 @@ var E023 = validation.NewCode("E023",
 // E024: There must not be empty directories within a version's content directory.
 var E024 = validation.NewCode("E024",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "There must not be empty directories within a version's content directory.",
 			URL:         "https://ocfl.io/1.0/spec/#E024",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "There must not be empty directories within a version's content directory.",
 			URL:         "https://ocfl.io/1.1/spec/#E024",
 		},
@@ -322,11 +322,11 @@ var E024 = validation.NewCode("E024",
 // E025: For content-addressing, OCFL Objects must use either sha512 or sha256, and should use sha512.
 var E025 = validation.NewCode("E025",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "For content-addressing, OCFL Objects must use either sha512 or sha256, and should use sha512.",
 			URL:         "https://ocfl.io/1.0/spec/#E025",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "For content-addressing, OCFL Objects must use either sha512 or sha256, and should use sha512.",
 			URL:         "https://ocfl.io/1.1/spec/#E025",
 		},
@@ -335,11 +335,11 @@ var E025 = validation.NewCode("E025",
 // E026: For storage of additional fixity values, or to support legacy content migration, implementers must choose from the following controlled vocabulary of digest algorithms, or from a list of additional algorithms given in the [Digest-Algorithms-Extension].
 var E026 = validation.NewCode("E026",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "For storage of additional fixity values, or to support legacy content migration, implementers must choose from the following controlled vocabulary of digest algorithms, or from a list of additional algorithms given in the [Digest-Algorithms-Extension].",
 			URL:         "https://ocfl.io/1.0/spec/#E026",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "For storage of additional fixity values, or to support legacy content migration, implementers must choose from the following controlled vocabulary of digest algorithms, or from a list of additional algorithms given in the [Digest-Algorithms-Extension].",
 			URL:         "https://ocfl.io/1.1/spec/#E026",
 		},
@@ -348,11 +348,11 @@ var E026 = validation.NewCode("E026",
 // E027: OCFL clients must support all fixity algorithms given in the table below, and may support additional algorithms from the extensions.
 var E027 = validation.NewCode("E027",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "OCFL clients must support all fixity algorithms given in the table below, and may support additional algorithms from the extensions.",
 			URL:         "https://ocfl.io/1.0/spec/#E027",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "OCFL clients must support all fixity algorithms given in the table below, and may support additional algorithms from the extensions.",
 			URL:         "https://ocfl.io/1.1/spec/#E027",
 		},
@@ -361,11 +361,11 @@ var E027 = validation.NewCode("E027",
 // E028: Optional fixity algorithms that are not supported by a client must be ignored by that client.
 var E028 = validation.NewCode("E028",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Optional fixity algorithms that are not supported by a client must be ignored by that client.",
 			URL:         "https://ocfl.io/1.0/spec/#E028",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Optional fixity algorithms that are not supported by a client must be ignored by that client.",
 			URL:         "https://ocfl.io/1.1/spec/#E028",
 		},
@@ -374,11 +374,11 @@ var E028 = validation.NewCode("E028",
 // E029: SHA-1 algorithm defined by [FIPS-180-4] and must be encoded using hex (base16) encoding [RFC4648].
 var E029 = validation.NewCode("E029",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "SHA-1 algorithm defined by [FIPS-180-4] and must be encoded using hex (base16) encoding [RFC4648].",
 			URL:         "https://ocfl.io/1.0/spec/#E029",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "SHA-1 algorithm defined by [FIPS-180-4] and must be encoded using hex (base16) encoding [RFC4648].",
 			URL:         "https://ocfl.io/1.1/spec/#E029",
 		},
@@ -387,11 +387,11 @@ var E029 = validation.NewCode("E029",
 // E030: SHA-256 algorithm defined by [FIPS-180-4] and must be encoded using hex (base16) encoding [RFC4648].
 var E030 = validation.NewCode("E030",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "SHA-256 algorithm defined by [FIPS-180-4] and must be encoded using hex (base16) encoding [RFC4648].",
 			URL:         "https://ocfl.io/1.0/spec/#E030",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "SHA-256 algorithm defined by [FIPS-180-4] and must be encoded using hex (base16) encoding [RFC4648].",
 			URL:         "https://ocfl.io/1.1/spec/#E030",
 		},
@@ -400,11 +400,11 @@ var E030 = validation.NewCode("E030",
 // E031: SHA-512 algorithm defined by [FIPS-180-4] and must be encoded using hex (base16) encoding [RFC4648].
 var E031 = validation.NewCode("E031",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "SHA-512 algorithm defined by [FIPS-180-4] and must be encoded using hex (base16) encoding [RFC4648].",
 			URL:         "https://ocfl.io/1.0/spec/#E031",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "SHA-512 algorithm defined by [FIPS-180-4] and must be encoded using hex (base16) encoding [RFC4648].",
 			URL:         "https://ocfl.io/1.1/spec/#E031",
 		},
@@ -413,11 +413,11 @@ var E031 = validation.NewCode("E031",
 // E032: [blake2b-512] must be encoded using hex (base16) encoding [RFC4648].
 var E032 = validation.NewCode("E032",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[blake2b-512] must be encoded using hex (base16) encoding [RFC4648].",
 			URL:         "https://ocfl.io/1.0/spec/#E032",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[blake2b-512] must be encoded using hex (base16) encoding [RFC4648].",
 			URL:         "https://ocfl.io/1.1/spec/#E032",
 		},
@@ -426,11 +426,11 @@ var E032 = validation.NewCode("E032",
 // E033: An OCFL Object Inventory MUST follow the [JSON] structure described in this section and must be named inventory.json.
 var E033 = validation.NewCode("E033",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "An OCFL Object Inventory MUST follow the [JSON] structure described in this section and must be named inventory.json.",
 			URL:         "https://ocfl.io/1.0/spec/#E033",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "An OCFL Object Inventory MUST follow the [JSON] structure described in this section and must be named inventory.json.",
 			URL:         "https://ocfl.io/1.1/spec/#E033",
 		},
@@ -439,11 +439,11 @@ var E033 = validation.NewCode("E033",
 // E034: An OCFL Object Inventory must follow the [JSON] structure described in this section and MUST be named inventory.json.
 var E034 = validation.NewCode("E034",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "An OCFL Object Inventory must follow the [JSON] structure described in this section and MUST be named inventory.json.",
 			URL:         "https://ocfl.io/1.0/spec/#E034",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "An OCFL Object Inventory must follow the [JSON] structure described in this section and MUST be named inventory.json.",
 			URL:         "https://ocfl.io/1.1/spec/#E034",
 		},
@@ -452,11 +452,11 @@ var E034 = validation.NewCode("E034",
 // E035: The forward slash (/) path separator must be used in content paths in the manifest and fixity blocks within the inventory.
 var E035 = validation.NewCode("E035",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The forward slash (/) path separator must be used in content paths in the manifest and fixity blocks within the inventory.",
 			URL:         "https://ocfl.io/1.0/spec/#E035",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The forward slash (/) path separator must be used in content paths in the manifest and fixity blocks within the inventory.",
 			URL:         "https://ocfl.io/1.1/spec/#E035",
 		},
@@ -465,11 +465,11 @@ var E035 = validation.NewCode("E035",
 // E036: An OCFL Object Inventory must include the following keys: [id, type, digestAlgorithm, head]
 var E036 = validation.NewCode("E036",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "An OCFL Object Inventory must include the following keys: [id, type, digestAlgorithm, head]",
 			URL:         "https://ocfl.io/1.0/spec/#E036",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "An OCFL Object Inventory must include the following keys: [id, type, digestAlgorithm, head]",
 			URL:         "https://ocfl.io/1.1/spec/#E036",
 		},
@@ -478,11 +478,11 @@ var E036 = validation.NewCode("E036",
 // E037: [id] must be unique in the local context, and should be a URI [RFC3986].
 var E037 = validation.NewCode("E037",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[id] must be unique in the local context, and should be a URI [RFC3986].",
 			URL:         "https://ocfl.io/1.0/spec/#E037",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[id] must be unique in the local context, and should be a URI [RFC3986].",
 			URL:         "https://ocfl.io/1.1/spec/#E037",
 		},
@@ -491,11 +491,11 @@ var E037 = validation.NewCode("E037",
 // E038: In the object root inventory [the type value] must be the URI of the inventory section of the specification version matching the object conformance declaration.
 var E038 = validation.NewCode("E038",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "In the object root inventory [the type value] must be the URI of the inventory section of the specification version matching the object conformance declaration.",
 			URL:         "https://ocfl.io/1.0/spec/#E038",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In the object root inventory [the type value] must be the URI of the inventory section of the specification version matching the object conformance declaration.",
 			URL:         "https://ocfl.io/1.1/spec/#E038",
 		},
@@ -504,11 +504,11 @@ var E038 = validation.NewCode("E038",
 // E039: [digestAlgorithm] must be the algorithm used in the manifest and state blocks.
 var E039 = validation.NewCode("E039",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[digestAlgorithm] must be the algorithm used in the manifest and state blocks.",
 			URL:         "https://ocfl.io/1.0/spec/#E039",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[digestAlgorithm] must be the algorithm used in the manifest and state blocks.",
 			URL:         "https://ocfl.io/1.1/spec/#E039",
 		},
@@ -517,11 +517,11 @@ var E039 = validation.NewCode("E039",
 // E040: [head] must be the version directory name with the highest ocfl.Number.
 var E040 = validation.NewCode("E040",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[head] must be the version directory name with the highest ocfl.Number.",
 			URL:         "https://ocfl.io/1.0/spec/#E040",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[head] must be the version directory name with the highest version number.",
 			URL:         "https://ocfl.io/1.1/spec/#E040",
 		},
@@ -530,11 +530,11 @@ var E040 = validation.NewCode("E040",
 // E041: In addition to these keys, there must be two other blocks present, manifest and versions, which are discussed in the next two sections.
 var E041 = validation.NewCode("E041",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "In addition to these keys, there must be two other blocks present, manifest and versions, which are discussed in the next two sections.",
 			URL:         "https://ocfl.io/1.0/spec/#E041",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In addition to these keys, there must be two other blocks present, manifest and versions, which are discussed in the next two sections.",
 			URL:         "https://ocfl.io/1.1/spec/#E041",
 		},
@@ -543,11 +543,11 @@ var E041 = validation.NewCode("E041",
 // E042: Content paths within a manifest block must be relative to the OCFL Object Root.
 var E042 = validation.NewCode("E042",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Content paths within a manifest block must be relative to the OCFL Object Root.",
 			URL:         "https://ocfl.io/1.0/spec/#E042",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Content paths within a manifest block must be relative to the OCFL Object Root.",
 			URL:         "https://ocfl.io/1.1/spec/#E042",
 		},
@@ -556,11 +556,11 @@ var E042 = validation.NewCode("E042",
 // E043: An OCFL Object Inventory must include a block for storing versions.
 var E043 = validation.NewCode("E043",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "An OCFL Object Inventory must include a block for storing versions.",
 			URL:         "https://ocfl.io/1.0/spec/#E043",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "An OCFL Object Inventory must include a block for storing versions.",
 			URL:         "https://ocfl.io/1.1/spec/#E043",
 		},
@@ -569,11 +569,11 @@ var E043 = validation.NewCode("E043",
 // E044: This block MUST have the key of versions within the inventory, and it must be a JSON object.
 var E044 = validation.NewCode("E044",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "This block MUST have the key of versions within the inventory, and it must be a JSON object.",
 			URL:         "https://ocfl.io/1.0/spec/#E044",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "This block MUST have the key of versions within the inventory, and it must be a JSON object.",
 			URL:         "https://ocfl.io/1.1/spec/#E044",
 		},
@@ -582,11 +582,11 @@ var E044 = validation.NewCode("E044",
 // E045: This block must have the key of versions within the inventory, and it MUST be a JSON object.
 var E045 = validation.NewCode("E045",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "This block must have the key of versions within the inventory, and it MUST be a JSON object.",
 			URL:         "https://ocfl.io/1.0/spec/#E045",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "This block must have the key of versions within the inventory, and it MUST be a JSON object.",
 			URL:         "https://ocfl.io/1.1/spec/#E045",
 		},
@@ -595,11 +595,11 @@ var E045 = validation.NewCode("E045",
 // E046: The keys of [the versions object] must correspond to the names of the version directories used.
 var E046 = validation.NewCode("E046",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The keys of [the versions object] must correspond to the names of the version directories used.",
 			URL:         "https://ocfl.io/1.0/spec/#E046",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The keys of [the versions object] must correspond to the names of the version directories used.",
 			URL:         "https://ocfl.io/1.1/spec/#E046",
 		},
@@ -608,11 +608,11 @@ var E046 = validation.NewCode("E046",
 // E047: Each value [of the versions object] must be another JSON object that characterizes the version, as described in the 3.5.3.1 Version section.
 var E047 = validation.NewCode("E047",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Each value [of the versions object] must be another JSON object that characterizes the version, as described in the 3.5.3.1 Version section.",
 			URL:         "https://ocfl.io/1.0/spec/#E047",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Each value [of the versions object] must be another JSON object that characterizes the version, as described in the 3.5.3.1 Version section.",
 			URL:         "https://ocfl.io/1.1/spec/#E047",
 		},
@@ -621,11 +621,11 @@ var E047 = validation.NewCode("E047",
 // E048: A JSON object to describe one OCFL Version, which must include the following keys: [created, state]
 var E048 = validation.NewCode("E048",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "A JSON object to describe one OCFL Version, which must include the following keys: [created, state]",
 			URL:         "https://ocfl.io/1.0/spec/#E048",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "A JSON object to describe one OCFL Version, which must include the following keys: [created, state]",
 			URL:         "https://ocfl.io/1.1/spec/#E048",
 		},
@@ -634,11 +634,11 @@ var E048 = validation.NewCode("E048",
 // E049: [the value of the \"created\" key] must be expressed in the Internet Date/Time Format defined by [RFC3339].
 var E049 = validation.NewCode("E049",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[the value of the \"created\" key] must be expressed in the Internet Date/Time Format defined by [RFC3339].",
 			URL:         "https://ocfl.io/1.0/spec/#E049",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[the value of the “created” key] must be expressed in the Internet Date/Time Format defined by [RFC3339].",
 			URL:         "https://ocfl.io/1.1/spec/#E049",
 		},
@@ -647,11 +647,11 @@ var E049 = validation.NewCode("E049",
 // E050: The keys of [the \"state\" JSON object] are digest values, each of which must correspond to an entry in the manifest of the inventory.
 var E050 = validation.NewCode("E050",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The keys of [the \"state\" JSON object] are digest values, each of which must correspond to an entry in the manifest of the inventory.",
 			URL:         "https://ocfl.io/1.0/spec/#E050",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The keys of [the “state” JSON object] are digest values, each of which must correspond to an entry in the manifest of the inventory.",
 			URL:         "https://ocfl.io/1.1/spec/#E050",
 		},
@@ -660,11 +660,11 @@ var E050 = validation.NewCode("E050",
 // E051: The logical path [value of a \"state\" digest key] must be interpreted as a set of one or more path elements joined by a / path separator.
 var E051 = validation.NewCode("E051",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The logical path [value of a \"state\" digest key] must be interpreted as a set of one or more path elements joined by a / path separator.",
 			URL:         "https://ocfl.io/1.0/spec/#E051",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The logical path [value of a “state” digest key] must be interpreted as a set of one or more path elements joined by a / path separator.",
 			URL:         "https://ocfl.io/1.1/spec/#E051",
 		},
@@ -673,11 +673,11 @@ var E051 = validation.NewCode("E051",
 // E052: [logical] Path elements must not be ., .., or empty (//).
 var E052 = validation.NewCode("E052",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[logical] Path elements must not be ., .., or empty (//).",
 			URL:         "https://ocfl.io/1.0/spec/#E052",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[logical] Path elements must not be ., .., or empty (//).",
 			URL:         "https://ocfl.io/1.1/spec/#E052",
 		},
@@ -686,11 +686,11 @@ var E052 = validation.NewCode("E052",
 // E053: Additionally, a logical path must not begin or end with a forward slash (/).
 var E053 = validation.NewCode("E053",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Additionally, a logical path must not begin or end with a forward slash (/).",
 			URL:         "https://ocfl.io/1.0/spec/#E053",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Additionally, a logical path must not begin or end with a forward slash (/).",
 			URL:         "https://ocfl.io/1.1/spec/#E053",
 		},
@@ -699,11 +699,11 @@ var E053 = validation.NewCode("E053",
 // E054: The value of the user key must contain a user name key, \"name\" and should contain an address key, \"address\".
 var E054 = validation.NewCode("E054",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The value of the user key must contain a user name key, \"name\" and should contain an address key, \"address\".",
 			URL:         "https://ocfl.io/1.0/spec/#E054",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The value of the user key must contain a user name key, “name” and should contain an address key, “address”.",
 			URL:         "https://ocfl.io/1.1/spec/#E054",
 		},
@@ -712,11 +712,11 @@ var E054 = validation.NewCode("E054",
 // E055: This block must have the key of fixity within the inventory.
 var E055 = validation.NewCode("E055",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "This block must have the key of fixity within the inventory.",
 			URL:         "https://ocfl.io/1.0/spec/#E055",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "If present, [the fixity] block must have the key of fixity within the inventory.",
 			URL:         "https://ocfl.io/1.1/spec/#E055",
 		},
@@ -725,11 +725,11 @@ var E055 = validation.NewCode("E055",
 // E056: The fixity block must contain keys corresponding to the controlled vocabulary given in the digest algorithms listed in the Digests section, or in a table given in an Extension.
 var E056 = validation.NewCode("E056",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The fixity block must contain keys corresponding to the controlled vocabulary given in the digest algorithms listed in the Digests section, or in a table given in an Extension.",
 			URL:         "https://ocfl.io/1.0/spec/#E056",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The fixity block must contain keys corresponding to the controlled vocabulary given in the digest algorithms listed in the Digests section, or in a table given in an Extension.",
 			URL:         "https://ocfl.io/1.1/spec/#E056",
 		},
@@ -738,11 +738,11 @@ var E056 = validation.NewCode("E056",
 // E057: The value of the fixity block for a particular digest algorithm must follow the structure of the manifest block; that is, a key corresponding to the digest value, and an array of content paths that match that digest.
 var E057 = validation.NewCode("E057",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The value of the fixity block for a particular digest algorithm must follow the structure of the manifest block; that is, a key corresponding to the digest value, and an array of content paths that match that digest.",
 			URL:         "https://ocfl.io/1.0/spec/#E057",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The value of the fixity block for a particular digest algorithm must follow the structure of the manifest block; that is, a key corresponding to the digest value, and an array of content paths that match that digest.",
 			URL:         "https://ocfl.io/1.1/spec/#E057",
 		},
@@ -751,11 +751,11 @@ var E057 = validation.NewCode("E057",
 // E058: Every occurrence of an inventory file must have an accompanying sidecar file stating its digest.
 var E058 = validation.NewCode("E058",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Every occurrence of an inventory file must have an accompanying sidecar file stating its digest.",
 			URL:         "https://ocfl.io/1.0/spec/#E058",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Every occurrence of an inventory file must have an accompanying sidecar file stating its digest.",
 			URL:         "https://ocfl.io/1.1/spec/#E058",
 		},
@@ -764,11 +764,11 @@ var E058 = validation.NewCode("E058",
 // E059: This value must match the value given for the digestAlgorithm key in the inventory.
 var E059 = validation.NewCode("E059",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "This value must match the value given for the digestAlgorithm key in the inventory.",
 			URL:         "https://ocfl.io/1.0/spec/#E059",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "This value must match the value given for the digestAlgorithm key in the inventory.",
 			URL:         "https://ocfl.io/1.1/spec/#E059",
 		},
@@ -777,11 +777,11 @@ var E059 = validation.NewCode("E059",
 // E060: The digest sidecar file must contain the digest of the inventory file.
 var E060 = validation.NewCode("E060",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The digest sidecar file must contain the digest of the inventory file.",
 			URL:         "https://ocfl.io/1.0/spec/#E060",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The digest sidecar file must contain the digest of the inventory file.",
 			URL:         "https://ocfl.io/1.1/spec/#E060",
 		},
@@ -790,11 +790,11 @@ var E060 = validation.NewCode("E060",
 // E061: [The digest sidecar file] must follow the format: DIGEST inventory.json
 var E061 = validation.NewCode("E061",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[The digest sidecar file] must follow the format: DIGEST inventory.json",
 			URL:         "https://ocfl.io/1.0/spec/#E061",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[The digest sidecar file] must follow the format: DIGEST inventory.json",
 			URL:         "https://ocfl.io/1.1/spec/#E061",
 		},
@@ -803,11 +803,11 @@ var E061 = validation.NewCode("E061",
 // E062: The digest of the inventory must be computed only after all changes to the inventory have been made, and thus writing the digest sidecar file is the last step in the versioning process.
 var E062 = validation.NewCode("E062",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The digest of the inventory must be computed only after all changes to the inventory have been made, and thus writing the digest sidecar file is the last step in the versioning process.",
 			URL:         "https://ocfl.io/1.0/spec/#E062",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The digest of the inventory must be computed only after all changes to the inventory have been made, and thus writing the digest sidecar file is the last step in the versioning process.",
 			URL:         "https://ocfl.io/1.1/spec/#E062",
 		},
@@ -816,11 +816,11 @@ var E062 = validation.NewCode("E062",
 // E063: Every OCFL Object must have an inventory file within the OCFL Object Root, corresponding to the state of the OCFL Object at the current version.
 var E063 = validation.NewCode("E063",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Every OCFL Object must have an inventory file within the OCFL Object Root, corresponding to the state of the OCFL Object at the current version.",
 			URL:         "https://ocfl.io/1.0/spec/#E063",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Every OCFL Object must have an inventory file within the OCFL Object Root, corresponding to the state of the OCFL Object at the current version.",
 			URL:         "https://ocfl.io/1.1/spec/#E063",
 		},
@@ -829,11 +829,11 @@ var E063 = validation.NewCode("E063",
 // E064: Where an OCFL Object contains inventory.json in version directories, the inventory file in the OCFL Object Root must be the same as the file in the most recent version.
 var E064 = validation.NewCode("E064",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Where an OCFL Object contains inventory.json in version directories, the inventory file in the OCFL Object Root must be the same as the file in the most recent version.",
 			URL:         "https://ocfl.io/1.0/spec/#E064",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Where an OCFL Object contains inventory.json in version directories, the inventory file in the OCFL Object Root must be the same as the file in the most recent version.",
 			URL:         "https://ocfl.io/1.1/spec/#E064",
 		},
@@ -842,11 +842,11 @@ var E064 = validation.NewCode("E064",
 // E066: Each version block in each prior inventory file must represent the same object state as the corresponding version block in the current inventory file.
 var E066 = validation.NewCode("E066",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Each version block in each prior inventory file must represent the same object state as the corresponding version block in the current inventory file.",
 			URL:         "https://ocfl.io/1.0/spec/#E066",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Each version block in each prior inventory file must represent the same object state as the corresponding version block in the current inventory file.",
 			URL:         "https://ocfl.io/1.1/spec/#E066",
 		},
@@ -855,11 +855,11 @@ var E066 = validation.NewCode("E066",
 // E067: The extensions directory must not contain any files, and no sub-directories other than extension sub-directories.
 var E067 = validation.NewCode("E067",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The extensions directory must not contain any files, and no sub-directories other than extension sub-directories.",
 			URL:         "https://ocfl.io/1.0/spec/#E067",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The extensions directory must not contain any files or sub-directories other than extension sub-directories.",
 			URL:         "https://ocfl.io/1.1/spec/#E067",
 		},
@@ -868,7 +868,7 @@ var E067 = validation.NewCode("E067",
 // E068: The specific structure and function of the extension, as well as a declaration of the registered extension name must be defined in one of the following locations: The OCFL Extensions repository OR The Storage Root, as a plain text document directly in the Storage Root.
 var E068 = validation.NewCode("E068",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The specific structure and function of the extension, as well as a declaration of the registered extension name must be defined in one of the following locations: The OCFL Extensions repository OR The Storage Root, as a plain text document directly in the Storage Root.",
 			URL:         "https://ocfl.io/1.0/spec/#E068",
 		},
@@ -877,11 +877,11 @@ var E068 = validation.NewCode("E068",
 // E069: An OCFL Storage Root MUST contain a Root Conformance Declaration identifying it as such.
 var E069 = validation.NewCode("E069",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "An OCFL Storage Root MUST contain a Root Conformance Declaration identifying it as such.",
 			URL:         "https://ocfl.io/1.0/spec/#E069",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "An OCFL Storage Root MUST contain a Root Conformance Declaration identifying it as such.",
 			URL:         "https://ocfl.io/1.1/spec/#E069",
 		},
@@ -890,11 +890,11 @@ var E069 = validation.NewCode("E069",
 // E070: If present, [the ocfl_layout.json document] MUST include the following two keys in the root JSON object: [key, description]
 var E070 = validation.NewCode("E070",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "If present, [the ocfl_layout.json document] MUST include the following two keys in the root JSON object: [key, description]",
 			URL:         "https://ocfl.io/1.0/spec/#E070",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "If present, [the ocfl_layout.json document] MUST include the following two keys in the root JSON object: [extension, description]",
 			URL:         "https://ocfl.io/1.1/spec/#E070",
 		},
@@ -903,11 +903,11 @@ var E070 = validation.NewCode("E070",
 // E071: The value of the [ocfl_layout.json] extension key must be the registered extension name for the extension defining the arrangement under the storage root.
 var E071 = validation.NewCode("E071",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The value of the [ocfl_layout.json] extension key must be the registered extension name for the extension defining the arrangement under the storage root.",
 			URL:         "https://ocfl.io/1.0/spec/#E071",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The value of the [ocfl_layout.json] extension key must be the registered extension name for the extension defining the arrangement under the storage root.",
 			URL:         "https://ocfl.io/1.1/spec/#E071",
 		},
@@ -916,11 +916,11 @@ var E071 = validation.NewCode("E071",
 // E072: The directory hierarchy used to store OCFL Objects MUST NOT contain files that are not part of an OCFL Object.
 var E072 = validation.NewCode("E072",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The directory hierarchy used to store OCFL Objects MUST NOT contain files that are not part of an OCFL Object.",
 			URL:         "https://ocfl.io/1.0/spec/#E072",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The directory hierarchy used to store OCFL Objects MUST NOT contain files that are not part of an OCFL Object.",
 			URL:         "https://ocfl.io/1.1/spec/#E072",
 		},
@@ -929,11 +929,11 @@ var E072 = validation.NewCode("E072",
 // E073: Empty directories MUST NOT appear under a storage root.
 var E073 = validation.NewCode("E073",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Empty directories MUST NOT appear under a storage root.",
 			URL:         "https://ocfl.io/1.0/spec/#E073",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Empty directories MUST NOT appear under a storage root.",
 			URL:         "https://ocfl.io/1.1/spec/#E073",
 		},
@@ -942,11 +942,11 @@ var E073 = validation.NewCode("E073",
 // E074: Although implementations may require multiple OCFL Storage Roots - that is, several logical or physical volumes, or multiple \"buckets\" in an object store - each OCFL Storage Root MUST be independent.
 var E074 = validation.NewCode("E074",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Although implementations may require multiple OCFL Storage Roots - that is, several logical or physical volumes, or multiple \"buckets\" in an object store - each OCFL Storage Root MUST be independent.",
 			URL:         "https://ocfl.io/1.0/spec/#E074",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Although implementations may require multiple OCFL Storage Roots - that is, several logical or physical volumes, or multiple “buckets” in an object store - each OCFL Storage Root MUST be independent.",
 			URL:         "https://ocfl.io/1.1/spec/#E074",
 		},
@@ -955,11 +955,11 @@ var E074 = validation.NewCode("E074",
 // E075: The OCFL version declaration MUST be formatted according to the NAMASTE specification.
 var E075 = validation.NewCode("E075",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The OCFL version declaration MUST be formatted according to the NAMASTE specification.",
 			URL:         "https://ocfl.io/1.0/spec/#E075",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The OCFL version declaration MUST be formatted according to the NAMASTE specification.",
 			URL:         "https://ocfl.io/1.1/spec/#E075",
 		},
@@ -968,11 +968,11 @@ var E075 = validation.NewCode("E075",
 // E076: [The OCFL version declaration] MUST be a file in the base directory of the OCFL Storage Root giving the OCFL version in the filename.
 var E076 = validation.NewCode("E076",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[The OCFL version declaration] MUST be a file in the base directory of the OCFL Storage Root giving the OCFL version in the filename.",
 			URL:         "https://ocfl.io/1.0/spec/#E076",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "There must be exactly one version declaration file in the base directory of the OCFL Storage Root giving the OCFL version in the filename.",
 			URL:         "https://ocfl.io/1.1/spec/#E076",
 		},
@@ -981,11 +981,11 @@ var E076 = validation.NewCode("E076",
 // E077: [The OCFL version declaration filename] MUST conform to the pattern T=dvalue, where T must be 0, and dvalue must be ocfl_, followed by the OCFL specification ocfl.Number.
 var E077 = validation.NewCode("E077",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[The OCFL version declaration filename] MUST conform to the pattern T=dvalue, where T must be 0, and dvalue must be ocfl_, followed by the OCFL specification ocfl.Number.",
 			URL:         "https://ocfl.io/1.0/spec/#E077",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[The OCFL version declaration filename] MUST conform to the pattern T=dvalue, where T must be 0, and dvalue must be ocfl_, followed by the OCFL specification version number.",
 			URL:         "https://ocfl.io/1.1/spec/#E077",
 		},
@@ -994,11 +994,11 @@ var E077 = validation.NewCode("E077",
 // E078: [The OCFL version declaration filename] must conform to the pattern T=dvalue, where T MUST be 0, and dvalue must be ocfl_, followed by the OCFL specification ocfl.Number.
 var E078 = validation.NewCode("E078",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[The OCFL version declaration filename] must conform to the pattern T=dvalue, where T MUST be 0, and dvalue must be ocfl_, followed by the OCFL specification ocfl.Number.",
 			URL:         "https://ocfl.io/1.0/spec/#E078",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[The OCFL version declaration filename] must conform to the pattern T=dvalue, where T MUST be 0, and dvalue must be ocfl_, followed by the OCFL specification version number.",
 			URL:         "https://ocfl.io/1.1/spec/#E078",
 		},
@@ -1007,11 +1007,11 @@ var E078 = validation.NewCode("E078",
 // E079: [The OCFL version declaration filename] must conform to the pattern T=dvalue, where T must be 0, and dvalue MUST be ocfl_, followed by the OCFL specification ocfl.Number.
 var E079 = validation.NewCode("E079",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[The OCFL version declaration filename] must conform to the pattern T=dvalue, where T must be 0, and dvalue MUST be ocfl_, followed by the OCFL specification ocfl.Number.",
 			URL:         "https://ocfl.io/1.0/spec/#E079",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[The OCFL version declaration filename] must conform to the pattern T=dvalue, where T must be 0, and dvalue MUST be ocfl_, followed by the OCFL specification version number.",
 			URL:         "https://ocfl.io/1.1/spec/#E079",
 		},
@@ -1020,11 +1020,11 @@ var E079 = validation.NewCode("E079",
 // E080: The text contents of [the OCFL version declaration file] MUST be the same as dvalue, followed by a newline (\n).
 var E080 = validation.NewCode("E080",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The text contents of [the OCFL version declaration file] MUST be the same as dvalue, followed by a newline (\n).",
 			URL:         "https://ocfl.io/1.0/spec/#E080",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The text contents of [the OCFL version declaration file] MUST be the same as dvalue, followed by a newline (\n).",
 			URL:         "https://ocfl.io/1.1/spec/#E080",
 		},
@@ -1033,11 +1033,11 @@ var E080 = validation.NewCode("E080",
 // E081: OCFL Objects within the OCFL Storage Root also include a conformance declaration which MUST indicate OCFL Object conformance to the same or earlier version of the specification.
 var E081 = validation.NewCode("E081",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "OCFL Objects within the OCFL Storage Root also include a conformance declaration which MUST indicate OCFL Object conformance to the same or earlier version of the specification.",
 			URL:         "https://ocfl.io/1.0/spec/#E081",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "OCFL Objects within the OCFL Storage Root also include a conformance declaration which MUST indicate OCFL Object conformance to the same or earlier version of the specification.",
 			URL:         "https://ocfl.io/1.1/spec/#E081",
 		},
@@ -1046,11 +1046,11 @@ var E081 = validation.NewCode("E081",
 // E082: OCFL Object Roots MUST be stored either as the terminal resource at the end of a directory storage hierarchy or as direct children of a containing OCFL Storage Root.
 var E082 = validation.NewCode("E082",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "OCFL Object Roots MUST be stored either as the terminal resource at the end of a directory storage hierarchy or as direct children of a containing OCFL Storage Root.",
 			URL:         "https://ocfl.io/1.0/spec/#E082",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "OCFL Object Roots MUST be stored either as the terminal resource at the end of a directory storage hierarchy or as direct children of a containing OCFL Storage Root.",
 			URL:         "https://ocfl.io/1.1/spec/#E082",
 		},
@@ -1059,11 +1059,11 @@ var E082 = validation.NewCode("E082",
 // E083: There MUST be a deterministic mapping from an object identifier to a unique storage path.
 var E083 = validation.NewCode("E083",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "There MUST be a deterministic mapping from an object identifier to a unique storage path.",
 			URL:         "https://ocfl.io/1.0/spec/#E083",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "There MUST be a deterministic mapping from an object identifier to a unique storage path.",
 			URL:         "https://ocfl.io/1.1/spec/#E083",
 		},
@@ -1072,11 +1072,11 @@ var E083 = validation.NewCode("E083",
 // E084: Storage hierarchies MUST NOT include files within intermediate directories.
 var E084 = validation.NewCode("E084",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Storage hierarchies MUST NOT include files within intermediate directories.",
 			URL:         "https://ocfl.io/1.0/spec/#E084",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Storage hierarchies MUST NOT include files within intermediate directories.",
 			URL:         "https://ocfl.io/1.1/spec/#E084",
 		},
@@ -1085,11 +1085,11 @@ var E084 = validation.NewCode("E084",
 // E085: Storage hierarchies MUST be terminated by OCFL Object Roots.
 var E085 = validation.NewCode("E085",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Storage hierarchies MUST be terminated by OCFL Object Roots.",
 			URL:         "https://ocfl.io/1.0/spec/#E085",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Storage hierarchies MUST be terminated by OCFL Object Roots.",
 			URL:         "https://ocfl.io/1.1/spec/#E085",
 		},
@@ -1098,7 +1098,7 @@ var E085 = validation.NewCode("E085",
 // E086: The storage root extensions directory MUST conform to the same guidelines and limitations as those defined for object extensions.
 var E086 = validation.NewCode("E086",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The storage root extensions directory MUST conform to the same guidelines and limitations as those defined for object extensions.",
 			URL:         "https://ocfl.io/1.0/spec/#E086",
 		},
@@ -1107,11 +1107,11 @@ var E086 = validation.NewCode("E086",
 // E087: An OCFL validator MUST ignore any files in the storage root it does not understand.
 var E087 = validation.NewCode("E087",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "An OCFL validator MUST ignore any files in the storage root it does not understand.",
 			URL:         "https://ocfl.io/1.0/spec/#E087",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "An OCFL validator MUST ignore any files in the storage root it does not understand.",
 			URL:         "https://ocfl.io/1.1/spec/#E087",
 		},
@@ -1120,11 +1120,11 @@ var E087 = validation.NewCode("E087",
 // E088: An OCFL Storage Root MUST NOT contain directories or sub-directories other than as a directory hierarchy used to store OCFL Objects or for storage root extensions.
 var E088 = validation.NewCode("E088",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "An OCFL Storage Root MUST NOT contain directories or sub-directories other than as a directory hierarchy used to store OCFL Objects or for storage root extensions.",
 			URL:         "https://ocfl.io/1.0/spec/#E088",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "An OCFL Storage Root MUST NOT contain directories or sub-directories other than as a directory hierarchy used to store OCFL Objects or for storage root extensions.",
 			URL:         "https://ocfl.io/1.1/spec/#E088",
 		},
@@ -1133,11 +1133,11 @@ var E088 = validation.NewCode("E088",
 // E089: If the preservation of non-OCFL-compliant features is required then the content MUST be wrapped in a suitable disk or filesystem image format which OCFL can treat as a regular file.
 var E089 = validation.NewCode("E089",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "If the preservation of non-OCFL-compliant features is required then the content MUST be wrapped in a suitable disk or filesystem image format which OCFL can treat as a regular file.",
 			URL:         "https://ocfl.io/1.0/spec/#E089",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "If the preservation of non-OCFL-compliant features is required then the content MUST be wrapped in a suitable disk or filesystem image format which OCFL can treat as a regular file.",
 			URL:         "https://ocfl.io/1.1/spec/#E089",
 		},
@@ -1146,11 +1146,11 @@ var E089 = validation.NewCode("E089",
 // E090: Hard and soft (symbolic) links are not portable and MUST NOT be used within OCFL Storage hierarchies.
 var E090 = validation.NewCode("E090",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Hard and soft (symbolic) links are not portable and MUST NOT be used within OCFL Storage hierarchies.",
 			URL:         "https://ocfl.io/1.0/spec/#E090",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Hard and soft (symbolic) links are not portable and MUST NOT be used within OCFL Storage hierarchies.",
 			URL:         "https://ocfl.io/1.1/spec/#E090",
 		},
@@ -1159,11 +1159,11 @@ var E090 = validation.NewCode("E090",
 // E091: Filesystems MUST preserve the case of OCFL filepaths and filenames.
 var E091 = validation.NewCode("E091",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Filesystems MUST preserve the case of OCFL filepaths and filenames.",
 			URL:         "https://ocfl.io/1.0/spec/#E091",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Filesystems MUST preserve the case of OCFL filepaths and filenames.",
 			URL:         "https://ocfl.io/1.1/spec/#E091",
 		},
@@ -1172,11 +1172,11 @@ var E091 = validation.NewCode("E091",
 // E092: The value for each key in the manifest must be an array containing the content paths of files in the OCFL Object that have content with the given digest.
 var E092 = validation.NewCode("E092",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The value for each key in the manifest must be an array containing the content paths of files in the OCFL Object that have content with the given digest.",
 			URL:         "https://ocfl.io/1.0/spec/#E092",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The value for each key in the manifest must be an array containing the content paths of files in the OCFL Object that have content with the given digest.",
 			URL:         "https://ocfl.io/1.1/spec/#E092",
 		},
@@ -1185,11 +1185,11 @@ var E092 = validation.NewCode("E092",
 // E093: Where included in the fixity block, the digest values given must match the digests of the files at the corresponding content paths.
 var E093 = validation.NewCode("E093",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Where included in the fixity block, the digest values given must match the digests of the files at the corresponding content paths.",
 			URL:         "https://ocfl.io/1.0/spec/#E093",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Where included in the fixity block, the digest values given must match the digests of the files at the corresponding content paths.",
 			URL:         "https://ocfl.io/1.1/spec/#E093",
 		},
@@ -1198,11 +1198,11 @@ var E093 = validation.NewCode("E093",
 // E094: The value of [the message] key is freeform text, used to record the rationale for creating this version. It must be a JSON string.
 var E094 = validation.NewCode("E094",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The value of [the message] key is freeform text, used to record the rationale for creating this version. It must be a JSON string.",
 			URL:         "https://ocfl.io/1.0/spec/#E094",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The value of [the message] key is freeform text, used to record the rationale for creating this version. It must be a JSON string.",
 			URL:         "https://ocfl.io/1.1/spec/#E094",
 		},
@@ -1211,11 +1211,11 @@ var E094 = validation.NewCode("E094",
 // E095: Within a version, logical paths must be unique and non-conflicting, so the logical path for a file cannot appear as the initial part of another logical path.
 var E095 = validation.NewCode("E095",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Within a version, logical paths must be unique and non-conflicting, so the logical path for a file cannot appear as the initial part of another logical path.",
 			URL:         "https://ocfl.io/1.0/spec/#E095",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Within a version, logical paths must be unique and non-conflicting, so the logical path for a file cannot appear as the initial part of another logical path.",
 			URL:         "https://ocfl.io/1.1/spec/#E095",
 		},
@@ -1224,11 +1224,11 @@ var E095 = validation.NewCode("E095",
 // E096: As JSON keys are case sensitive, while digests may not be, there is an additional requirement that each digest value must occur only once in the manifest regardless of case.
 var E096 = validation.NewCode("E096",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "As JSON keys are case sensitive, while digests may not be, there is an additional requirement that each digest value must occur only once in the manifest regardless of case.",
 			URL:         "https://ocfl.io/1.0/spec/#E096",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "As JSON keys are case sensitive, while digests may not be, there is an additional requirement that each digest value must occur only once in the manifest regardless of case.",
 			URL:         "https://ocfl.io/1.1/spec/#E096",
 		},
@@ -1237,11 +1237,11 @@ var E096 = validation.NewCode("E096",
 // E097: As JSON keys are case sensitive, while digests may not be, there is an additional requirement that each digest value must occur only once in the fixity block for any digest algorithm, regardless of case.
 var E097 = validation.NewCode("E097",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "As JSON keys are case sensitive, while digests may not be, there is an additional requirement that each digest value must occur only once in the fixity block for any digest algorithm, regardless of case.",
 			URL:         "https://ocfl.io/1.0/spec/#E097",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "As JSON keys are case sensitive, while digests may not be, there is an additional requirement that each digest value must occur only once in the fixity block for any digest algorithm, regardless of case.",
 			URL:         "https://ocfl.io/1.1/spec/#E097",
 		},
@@ -1250,11 +1250,11 @@ var E097 = validation.NewCode("E097",
 // E098: The content path must be interpreted as a set of one or more path elements joined by a / path separator.
 var E098 = validation.NewCode("E098",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The content path must be interpreted as a set of one or more path elements joined by a / path separator.",
 			URL:         "https://ocfl.io/1.0/spec/#E098",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The content path must be interpreted as a set of one or more path elements joined by a / path separator.",
 			URL:         "https://ocfl.io/1.1/spec/#E098",
 		},
@@ -1263,11 +1263,11 @@ var E098 = validation.NewCode("E098",
 // E099: [content] path elements must not be ., .., or empty (//).
 var E099 = validation.NewCode("E099",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "[content] path elements must not be ., .., or empty (//).",
 			URL:         "https://ocfl.io/1.0/spec/#E099",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "[content] path elements must not be ., .., or empty (//).",
 			URL:         "https://ocfl.io/1.1/spec/#E099",
 		},
@@ -1276,11 +1276,11 @@ var E099 = validation.NewCode("E099",
 // E100: A content path must not begin or end with a forward slash (/).
 var E100 = validation.NewCode("E100",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "A content path must not begin or end with a forward slash (/).",
 			URL:         "https://ocfl.io/1.0/spec/#E100",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "A content path must not begin or end with a forward slash (/).",
 			URL:         "https://ocfl.io/1.1/spec/#E100",
 		},
@@ -1289,11 +1289,11 @@ var E100 = validation.NewCode("E100",
 // E101: Within an inventory, content paths must be unique and non-conflicting, so the content path for a file cannot appear as the initial part of another content path.
 var E101 = validation.NewCode("E101",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Within an inventory, content paths must be unique and non-conflicting, so the content path for a file cannot appear as the initial part of another content path.",
 			URL:         "https://ocfl.io/1.0/spec/#E101",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Within an inventory, content paths must be unique and non-conflicting, so the content path for a file cannot appear as the initial part of another content path.",
 			URL:         "https://ocfl.io/1.1/spec/#E101",
 		},
@@ -1302,11 +1302,11 @@ var E101 = validation.NewCode("E101",
 // E102: An inventory file must not contain keys that are not specified.
 var E102 = validation.NewCode("E102",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "An inventory file must not contain keys that are not specified.",
 			URL:         "https://ocfl.io/1.0/spec/#E102",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "An inventory file must not contain keys that are not specified.",
 			URL:         "https://ocfl.io/1.1/spec/#E102",
 		},
@@ -1315,7 +1315,7 @@ var E102 = validation.NewCode("E102",
 // E103: Each version directory within an OCFL Object MUST conform to either the same or a later OCFL specification version as the preceding version directory.
 var E103 = validation.NewCode("E103",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Each version directory within an OCFL Object MUST conform to either the same or a later OCFL specification version as the preceding version directory.",
 			URL:         "https://ocfl.io/1.1/spec/#E103",
 		},
@@ -1324,7 +1324,7 @@ var E103 = validation.NewCode("E103",
 // E104: Version directory names MUST be constructed by prepending v to the version number.
 var E104 = validation.NewCode("E104",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Version directory names MUST be constructed by prepending v to the version number.",
 			URL:         "https://ocfl.io/1.1/spec/#E104",
 		},
@@ -1333,7 +1333,7 @@ var E104 = validation.NewCode("E104",
 // E105: The version number MUST be taken from the sequence of positive, base-ten integers: 1, 2, 3, etc.
 var E105 = validation.NewCode("E105",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The version number MUST be taken from the sequence of positive, base-ten integers: 1, 2, 3, etc.",
 			URL:         "https://ocfl.io/1.1/spec/#E105",
 		},
@@ -1342,7 +1342,7 @@ var E105 = validation.NewCode("E105",
 // E106: The value of the manifest key MUST be a JSON object.
 var E106 = validation.NewCode("E106",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The value of the manifest key MUST be a JSON object.",
 			URL:         "https://ocfl.io/1.1/spec/#E106",
 		},
@@ -1351,7 +1351,7 @@ var E106 = validation.NewCode("E106",
 // E107: The value of the manifest key must be a JSON object, and each key MUST correspond to a digest value key found in one or more state blocks of the current and/or previous version blocks of the OCFL Object.
 var E107 = validation.NewCode("E107",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The value of the manifest key must be a JSON object, and each key MUST correspond to a digest value key found in one or more state blocks of the current and/or previous version blocks of the OCFL Object.",
 			URL:         "https://ocfl.io/1.1/spec/#E107",
 		},
@@ -1360,7 +1360,7 @@ var E107 = validation.NewCode("E107",
 // E108: The contentDirectory value MUST represent a direct child directory of the version directory in which it is found.
 var E108 = validation.NewCode("E108",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The contentDirectory value MUST represent a direct child directory of the version directory in which it is found.",
 			URL:         "https://ocfl.io/1.1/spec/#E108",
 		},
@@ -1369,7 +1369,7 @@ var E108 = validation.NewCode("E108",
 // E110: A unique identifier for the OCFL Object MUST NOT change between versions of the same object.
 var E110 = validation.NewCode("E110",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "A unique identifier for the OCFL Object MUST NOT change between versions of the same object.",
 			URL:         "https://ocfl.io/1.1/spec/#E110",
 		},
@@ -1378,7 +1378,7 @@ var E110 = validation.NewCode("E110",
 // E111: If present, [the value of the fixity key] MUST be a JSON object, which may be empty.
 var E111 = validation.NewCode("E111",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "If present, [the value of the fixity key] MUST be a JSON object, which may be empty.",
 			URL:         "https://ocfl.io/1.1/spec/#E111",
 		},
@@ -1387,7 +1387,7 @@ var E111 = validation.NewCode("E111",
 // E112: The extensions directory must not contain any files or sub-directories other than extension sub-directories.
 var E112 = validation.NewCode("E112",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The extensions directory must not contain any files or sub-directories other than extension sub-directories.",
 			URL:         "https://ocfl.io/1.1/spec/#E112",
 		},
@@ -1396,11 +1396,11 @@ var E112 = validation.NewCode("E112",
 // W001: Implementations SHOULD use version directory names constructed without zero-padding the ocfl.Number, ie. v1, v2, v3, etc.
 var W001 = validation.NewCode("W001",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Implementations SHOULD use version directory names constructed without zero-padding the ocfl.Number, ie. v1, v2, v3, etc.",
 			URL:         "https://ocfl.io/1.0/spec/#W001",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Implementations SHOULD use version directory names constructed without zero-padding the version number, ie. v1, v2, v3, etc.",
 			URL:         "https://ocfl.io/1.1/spec/#W001",
 		},
@@ -1409,11 +1409,11 @@ var W001 = validation.NewCode("W001",
 // W002: The version directory SHOULD NOT contain any directories other than the designated content sub-directory. Once created, the contents of a version directory are expected to be immutable.
 var W002 = validation.NewCode("W002",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The version directory SHOULD NOT contain any directories other than the designated content sub-directory. Once created, the contents of a version directory are expected to be immutable.",
 			URL:         "https://ocfl.io/1.0/spec/#W002",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The version directory SHOULD NOT contain any directories other than the designated content sub-directory. Once created, the contents of a version directory are expected to be immutable.",
 			URL:         "https://ocfl.io/1.1/spec/#W002",
 		},
@@ -1422,11 +1422,11 @@ var W002 = validation.NewCode("W002",
 // W003: Version directories must contain a designated content sub-directory if the version contains files to be preserved, and SHOULD NOT contain this sub-directory otherwise.
 var W003 = validation.NewCode("W003",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Version directories must contain a designated content sub-directory if the version contains files to be preserved, and SHOULD NOT contain this sub-directory otherwise.",
 			URL:         "https://ocfl.io/1.0/spec/#W003",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Version directories must contain a designated content sub-directory if the version contains files to be preserved, and SHOULD NOT contain this sub-directory otherwise.",
 			URL:         "https://ocfl.io/1.1/spec/#W003",
 		},
@@ -1435,11 +1435,11 @@ var W003 = validation.NewCode("W003",
 // W004: For content-addressing, OCFL Objects SHOULD use sha512.
 var W004 = validation.NewCode("W004",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "For content-addressing, OCFL Objects SHOULD use sha512.",
 			URL:         "https://ocfl.io/1.0/spec/#W004",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "For content-addressing, OCFL Objects SHOULD use sha512.",
 			URL:         "https://ocfl.io/1.1/spec/#W004",
 		},
@@ -1448,11 +1448,11 @@ var W004 = validation.NewCode("W004",
 // W005: The OCFL Object Inventory id SHOULD be a URI.
 var W005 = validation.NewCode("W005",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "The OCFL Object Inventory id SHOULD be a URI.",
 			URL:         "https://ocfl.io/1.0/spec/#W005",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "The OCFL Object Inventory id SHOULD be a URI.",
 			URL:         "https://ocfl.io/1.1/spec/#W005",
 		},
@@ -1461,11 +1461,11 @@ var W005 = validation.NewCode("W005",
 // W007: In the OCFL Object Inventory, the JSON object describing an OCFL Version, SHOULD include the message and user keys.
 var W007 = validation.NewCode("W007",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "In the OCFL Object Inventory, the JSON object describing an OCFL Version, SHOULD include the message and user keys.",
 			URL:         "https://ocfl.io/1.0/spec/#W007",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In the OCFL Object Inventory, the JSON object describing an OCFL Version, SHOULD include the message and user keys.",
 			URL:         "https://ocfl.io/1.1/spec/#W007",
 		},
@@ -1474,11 +1474,11 @@ var W007 = validation.NewCode("W007",
 // W008: In the OCFL Object Inventory, in the version block, the value of the user key SHOULD contain an address key, address.
 var W008 = validation.NewCode("W008",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "In the OCFL Object Inventory, in the version block, the value of the user key SHOULD contain an address key, address.",
 			URL:         "https://ocfl.io/1.0/spec/#W008",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In the OCFL Object Inventory, in the version block, the value of the user key SHOULD contain an address key, address.",
 			URL:         "https://ocfl.io/1.1/spec/#W008",
 		},
@@ -1487,11 +1487,11 @@ var W008 = validation.NewCode("W008",
 // W009: In the OCFL Object Inventory, in the version block, the address value SHOULD be a URI: either a mailto URI [RFC6068] with the e-mail address of the user or a URL to a personal identifier, e.g., an ORCID iD.
 var W009 = validation.NewCode("W009",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "In the OCFL Object Inventory, in the version block, the address value SHOULD be a URI: either a mailto URI [RFC6068] with the e-mail address of the user or a URL to a personal identifier, e.g., an ORCID iD.",
 			URL:         "https://ocfl.io/1.0/spec/#W009",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In the OCFL Object Inventory, in the version block, the address value SHOULD be a URI: either a mailto URI [RFC6068] with the e-mail address of the user or a URL to a personal identifier, e.g., an ORCID iD.",
 			URL:         "https://ocfl.io/1.1/spec/#W009",
 		},
@@ -1500,11 +1500,11 @@ var W009 = validation.NewCode("W009",
 // W010: In addition to the inventory in the OCFL Object Root, every version directory SHOULD include an inventory file that is an Inventory of all content for versions up to and including that particular version.
 var W010 = validation.NewCode("W010",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "In addition to the inventory in the OCFL Object Root, every version directory SHOULD include an inventory file that is an Inventory of all content for versions up to and including that particular version.",
 			URL:         "https://ocfl.io/1.0/spec/#W010",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In addition to the inventory in the OCFL Object Root, every version directory SHOULD include an inventory file that is an Inventory of all content for versions up to and including that particular version.",
 			URL:         "https://ocfl.io/1.1/spec/#W010",
 		},
@@ -1513,11 +1513,11 @@ var W010 = validation.NewCode("W010",
 // W011: In the case that prior version directories include an inventory file, the values of the created, message and user keys in each version block in each prior inventory file SHOULD have the same values as the corresponding keys in the corresponding version block in the current inventory file.
 var W011 = validation.NewCode("W011",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "In the case that prior version directories include an inventory file, the values of the created, message and user keys in each version block in each prior inventory file SHOULD have the same values as the corresponding keys in the corresponding version block in the current inventory file.",
 			URL:         "https://ocfl.io/1.0/spec/#W011",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In the case that prior version directories include an inventory file, the values of the created, message and user keys in each version block in each prior inventory file SHOULD have the same values as the corresponding keys in the corresponding version block in the current inventory file.",
 			URL:         "https://ocfl.io/1.1/spec/#W011",
 		},
@@ -1526,11 +1526,11 @@ var W011 = validation.NewCode("W011",
 // W012: Implementers SHOULD use the logs directory, if present, for storing files that contain a record of actions taken on the object.
 var W012 = validation.NewCode("W012",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Implementers SHOULD use the logs directory, if present, for storing files that contain a record of actions taken on the object.",
 			URL:         "https://ocfl.io/1.0/spec/#W012",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Implementers SHOULD use the logs directory, if present, for storing files that contain a record of actions taken on the object.",
 			URL:         "https://ocfl.io/1.1/spec/#W012",
 		},
@@ -1539,11 +1539,11 @@ var W012 = validation.NewCode("W012",
 // W013: In an OCFL Object, extension sub-directories SHOULD be named according to a registered extension name.
 var W013 = validation.NewCode("W013",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "In an OCFL Object, extension sub-directories SHOULD be named according to a registered extension name.",
 			URL:         "https://ocfl.io/1.0/spec/#W013",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In an OCFL Object, extension sub-directories SHOULD be named according to a registered extension name.",
 			URL:         "https://ocfl.io/1.1/spec/#W013",
 		},
@@ -1552,11 +1552,11 @@ var W013 = validation.NewCode("W013",
 // W014: Storage hierarchies within the same OCFL Storage Root SHOULD use just one layout pattern.
 var W014 = validation.NewCode("W014",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Storage hierarchies within the same OCFL Storage Root SHOULD use just one layout pattern.",
 			URL:         "https://ocfl.io/1.0/spec/#W014",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Storage hierarchies within the same OCFL Storage Root SHOULD use just one layout pattern.",
 			URL:         "https://ocfl.io/1.1/spec/#W014",
 		},
@@ -1565,11 +1565,11 @@ var W014 = validation.NewCode("W014",
 // W015: Storage hierarchies within the same OCFL Storage Root SHOULD consistently use either a directory hierarchy of OCFL Objects or top-level OCFL Objects.
 var W015 = validation.NewCode("W015",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 0}: {
+		ocfl.Spec1_0: {
 			Description: "Storage hierarchies within the same OCFL Storage Root SHOULD consistently use either a directory hierarchy of OCFL Objects or top-level OCFL Objects.",
 			URL:         "https://ocfl.io/1.0/spec/#W015",
 		},
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "Storage hierarchies within the same OCFL Storage Root SHOULD consistently use either a directory hierarchy of OCFL Objects or top-level OCFL Objects.",
 			URL:         "https://ocfl.io/1.1/spec/#W015",
 		},
@@ -1578,7 +1578,7 @@ var W015 = validation.NewCode("W015",
 // W016: In the Storage Root, extension sub-directories SHOULD be named according to a registered extension name.
 var W016 = validation.NewCode("W016",
 	map[ocfl.Spec]*validation.Ref{
-		{1, 1}: {
+		ocfl.Spec1_1: {
 			Description: "In the Storage Root, extension sub-directories SHOULD be named according to a registered extension name.",
 			URL:         "https://ocfl.io/1.1/spec/#W016",
 		},

--- a/ocflv1/codes/generate/gen.go
+++ b/ocflv1/codes/generate/gen.go
@@ -54,9 +54,8 @@ func main() {
 			desc := row[1]
 			url := row[2]
 			comment := fmt.Sprintf("%s: %s", row[0], row[1])
-			v := ocfl.MustParseSpec(specnum)
 			if code := codes[num]; code != nil {
-				code.Specs[v] = Spec{
+				code.Specs[ocfl.Spec(specnum)] = Spec{
 					Description: desc,
 					URL:         url,
 				}
@@ -66,7 +65,7 @@ func main() {
 				Num:     num,
 				Comment: comment,
 				Specs: map[ocfl.Spec]Spec{
-					v: {
+					ocfl.Spec(specnum): {
 						Description: desc,
 						URL:         url,
 					},

--- a/ocflv1/commit.go
+++ b/ocflv1/commit.go
@@ -173,7 +173,7 @@ func Commit(ctx context.Context, fsys ocfl.WriteFS, objPath string, objID string
 	// Mutate object: new object declaration if necessary
 	if existObj == nil {
 		opts.logger.DebugContext(ctx, "initializing new OCFL object")
-		decl := ocfl.Declaration{Type: ocfl.DeclObject, Version: newInv.Type.Spec}
+		decl := ocfl.Namaste{Type: ocfl.DeclObject, Version: newInv.Type.Spec}
 		if err = ocfl.WriteDeclaration(ctx, fsys, objPath, decl); err != nil {
 			return &CommitError{Err: err, Dirty: true}
 		}

--- a/ocflv1/commit.go
+++ b/ocflv1/commit.go
@@ -173,7 +173,7 @@ func Commit(ctx context.Context, fsys ocfl.WriteFS, objPath string, objID string
 	// Mutate object: new object declaration if necessary
 	if existObj == nil {
 		opts.logger.DebugContext(ctx, "initializing new OCFL object")
-		decl := ocfl.Namaste{Type: ocfl.DeclObject, Version: newInv.Type.Spec}
+		decl := ocfl.Namaste{Type: ocfl.NamasteTypeObject, Version: newInv.Type.Spec}
 		if err = ocfl.WriteDeclaration(ctx, fsys, objPath, decl); err != nil {
 			return &CommitError{Err: err, Dirty: true}
 		}

--- a/ocflv1/object_validation.go
+++ b/ocflv1/object_validation.go
@@ -57,9 +57,9 @@ func (vldr *objectValidator) validate(ctx context.Context) *validation.Result {
 	vldr.root = obj
 	ocflV := vldr.root.Spec
 	switch ocflV {
-	case ocfl.Spec{1, 0}:
+	case ocfl.Spec1_0:
 		fallthrough
-	case ocfl.Spec{1, 1}:
+	case ocfl.Spec1_1:
 		if err := vldr.validateRoot(ctx); err != nil {
 			return vldr.Result
 		}

--- a/ocflv1/object_validation.go
+++ b/ocflv1/object_validation.go
@@ -103,7 +103,7 @@ func (vldr *objectValidator) validate(ctx context.Context) *validation.Result {
 func (vldr *objectValidator) validateRoot(ctx context.Context) error {
 	ocflV := vldr.root.Spec
 	lgr := vldr.opts.Logger
-	if err := vldr.root.ValidateDeclaration(ctx); err != nil {
+	if err := vldr.root.ValidateNamaste(ctx); err != nil {
 		err = ec(err, codes.E007.Ref(ocflV))
 		vldr.LogFatal(lgr, err)
 	}

--- a/ocflv1/object_validation.go
+++ b/ocflv1/object_validation.go
@@ -93,7 +93,7 @@ func (vldr *objectValidator) validate(ctx context.Context) *validation.Result {
 			return vldr.Result
 		}
 	default:
-		err := fmt.Errorf("%w: %s", ErrOCFLVersion, ocflV.String())
+		err := fmt.Errorf("%w: %s", ErrOCFLVersion, ocflV)
 		return vldr.LogFatal(lgr, err)
 	}
 	return vldr.Result

--- a/ocflv1/ocflv1.go
+++ b/ocflv1/ocflv1.go
@@ -20,8 +20,8 @@ const (
 )
 
 var (
-	ocflv1_0    = ocfl.Spec{1, 0}
-	ocflv1_1    = ocfl.Spec{1, 1}
+	ocflv1_0    = ocfl.Spec1_0
+	ocflv1_1    = ocfl.Spec1_1
 	defaultSpec = ocflv1_1
 
 	// supported versions

--- a/ocflv1/ocflv1.go
+++ b/ocflv1/ocflv1.go
@@ -13,7 +13,7 @@ const (
 	digestAlgorithm     = "sha512"
 	extensionsDir       = "extensions"
 	layoutName          = "ocfl_layout.json"
-	storeRoot           = ocfl.DeclStore
+	storeRoot           = ocfl.NamasteTypeStore
 	descriptionKey      = `description`
 	extensionKey        = `extension`
 	extensionConfigFile = "config.json"
@@ -29,15 +29,6 @@ var (
 		ocflv1_0: true,
 		ocflv1_1: true,
 	}
-
-	// algs set to true can be used as digestAlgorithms
-	// algorithms = map[ocfl.Alg]bool{
-	// 	ocfl.SHA512:  true,
-	// 	ocfl.SHA256:  true,
-	// 	ocfl.SHA1:    false,
-	// 	ocfl.MD5:     false,
-	// 	ocfl.BLAKE2B: false,
-	// }
 
 	// shorthand
 	ec = validation.NewErrorCode

--- a/ocflv1/store.go
+++ b/ocflv1/store.go
@@ -58,7 +58,7 @@ func InitStore(ctx context.Context, fsys ocfl.WriteFS, root string, conf *InitSt
 	if conf.Layout == nil {
 		conf.Layout = &extension.LayoutFlatDirect{}
 	}
-	decl := ocfl.Declaration{
+	decl := ocfl.Namaste{
 		Type:    ocfl.DeclStore,
 		Version: conf.Spec,
 	}
@@ -117,8 +117,8 @@ func GetStore(ctx context.Context, fsys ocfl.FS, root string) (*Store, error) {
 	// root declarations until we find one (or return error)
 	var ocflVer ocfl.Spec
 	for _, s := range []ocfl.Spec{ocflv1_1, ocflv1_0} {
-		decl := ocfl.Declaration{Type: ocfl.DeclStore, Version: s}.Name()
-		if err := ocfl.ReadDeclaration(ctx, fsys, path.Join(root, decl)); err != nil {
+		decl := ocfl.Namaste{Type: ocfl.DeclStore, Version: s}.Name()
+		if err := ocfl.ReadNamaste(ctx, fsys, path.Join(root, decl)); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
@@ -128,7 +128,7 @@ func GetStore(ctx context.Context, fsys ocfl.FS, root string) (*Store, error) {
 		break
 	}
 	if ocflVer.Empty() {
-		return nil, fmt.Errorf("missing storage root declaration: %w", ocfl.ErrDeclNotExist)
+		return nil, fmt.Errorf("missing storage root declaration: %w", ocfl.ErrNoNamaste)
 	}
 	str := &Store{
 		fsys:    fsys,

--- a/ocflv1/store.go
+++ b/ocflv1/store.go
@@ -48,7 +48,7 @@ func InitStore(ctx context.Context, fsys ocfl.WriteFS, root string, conf *InitSt
 	if conf == nil {
 		conf = &InitStoreConf{}
 	}
-	if conf.Spec == (ocfl.Spec{}) {
+	if conf.Spec.Empty() {
 		conf.Spec = defaultSpec
 	}
 	if !ocflVerSupported[conf.Spec] {

--- a/ocflv1/store.go
+++ b/ocflv1/store.go
@@ -59,7 +59,7 @@ func InitStore(ctx context.Context, fsys ocfl.WriteFS, root string, conf *InitSt
 		conf.Layout = &extension.LayoutFlatDirect{}
 	}
 	decl := ocfl.Namaste{
-		Type:    ocfl.DeclStore,
+		Type:    ocfl.NamasteTypeStore,
 		Version: conf.Spec,
 	}
 	entries, err := fsys.ReadDir(ctx, root)
@@ -117,7 +117,7 @@ func GetStore(ctx context.Context, fsys ocfl.FS, root string) (*Store, error) {
 	// root declarations until we find one (or return error)
 	var ocflVer ocfl.Spec
 	for _, s := range []ocfl.Spec{ocflv1_1, ocflv1_0} {
-		decl := ocfl.Namaste{Type: ocfl.DeclStore, Version: s}.Name()
+		decl := ocfl.Namaste{Type: ocfl.NamasteTypeStore, Version: s}.Name()
 		if err := ocfl.ReadNamaste(ctx, fsys, path.Join(root, decl)); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				continue

--- a/ocflv1/store_test.go
+++ b/ocflv1/store_test.go
@@ -141,7 +141,7 @@ func TestStoreCommit(t *testing.T) {
 	storeFS := memfs.New() // store
 	// initialize store
 	if err := ocflv1.InitStore(ctx, storeFS, storePath, &ocflv1.InitStoreConf{
-		Spec: ocfl.Spec{1, 0},
+		Spec: ocfl.Spec1_0,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestStoreCommit(t *testing.T) {
 
 	t.Run("with invalid spec", func(t *testing.T) {
 		stage := &ocfl.Stage{State: ocfl.DigestMap{}, DigestAlgorithm: "sha256"}
-		err := store.Commit(ctx, "object-0", stage, ocflv1.WithOCFLSpec(ocfl.Spec{1, 1}))
+		err := store.Commit(ctx, "object-0", stage, ocflv1.WithOCFLSpec(ocfl.Spec1_1))
 		if err == nil {
 			t.Fatal("expected an error")
 		}

--- a/ocflv1/store_validation.go
+++ b/ocflv1/store_validation.go
@@ -167,11 +167,11 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 		}
 		decl, _ := ocfl.FindNamaste(entries)
 		switch decl.Type {
-		case ocfl.DeclObject:
+		case ocfl.NamasteTypeObject:
 			objRoot := ocfl.NewObjectRoot(fsys, name, entries)
 			validateObjectRoot(objRoot)
 			return walkdirs.ErrSkipDirs // don't continue scan further into the object
-		case ocfl.DeclStore:
+		case ocfl.NamasteTypeStore:
 			// store within a store is an error
 			if name != root {
 				err := fmt.Errorf("%w: %s", ErrNonObject, name)

--- a/ocflv1/store_validation.go
+++ b/ocflv1/store_validation.go
@@ -26,7 +26,7 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 	//E076: [The OCFL version declaration] MUST be a file in the base
 	//directory of the OCFL Storage Root giving the OCFL version in the
 	//filename.
-	decl, err := ocfl.FindDeclaration(inf)
+	decl, err := ocfl.FindNamaste(inf)
 	if err != nil {
 		err := fmt.Errorf("not an ocfl storage root: %w", err)
 		return result.LogFatal(lgr, ec(err, codes.E076.Ref(ocflv1_0)))
@@ -44,7 +44,7 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 	//NAMASTE specification.
 	//E080: The text contents of [the OCFL version declaration file] MUST be
 	//the same as dvalue, followed by a newline (\n).
-	err = ocfl.ReadDeclaration(ctx, fsys, path.Join(root, decl.Name()))
+	err = ocfl.ReadNamaste(ctx, fsys, path.Join(root, decl.Name()))
 	if err != nil {
 		result.LogFatal(lgr, ec(err, codes.E080.Ref(ocflV)))
 	}
@@ -165,7 +165,7 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 		if err != nil {
 			return err
 		}
-		decl, _ := ocfl.FindDeclaration(entries)
+		decl, _ := ocfl.FindNamaste(entries)
 		switch decl.Type {
 		case ocfl.DeclObject:
 			objRoot := ocfl.NewObjectRoot(fsys, name, entries)

--- a/spec.go
+++ b/spec.go
@@ -21,12 +21,11 @@ const (
 )
 
 var (
-	// specs lists known OCFL specification in the
-	// order they were published
-	specs = []Spec{Spec1_0, Spec1_1}
-
 	ErrSpecInvalid  = errors.New("invalid OCFL spec version")
 	ErrSpecNotFound = errors.New("OCFL spec file not found")
+
+	// specs lists known OCFL specifications in the  order they were published
+	specs = []Spec{Spec1_0, Spec1_1}
 )
 
 //go:embed specs/*

--- a/spec_test.go
+++ b/spec_test.go
@@ -17,28 +17,25 @@ type vNumTest struct {
 
 var vNumTable = []vNumTest{
 	// valid
-	{`1.0`, ocfl.Spec{1, 0}, true},
-	{`1.1`, ocfl.Spec{1, 1}, true},
-	{`100.11`, ocfl.Spec{100, 11}, true},
-	{`100.119999`, ocfl.Spec{100, 119999}, true},
+	{`1.0`, ocfl.Spec1_0, true},
+	{`1.1`, ocfl.Spec1_1, true},
 
 	// invalid
-	{`1.00`, ocfl.Spec{0, 0}, false},
-	{`10`, ocfl.Spec{0, 0}, false},
-	{`0`, ocfl.Spec{0, 0}, false},
-	{``, ocfl.Spec{0, 0}, false},
-	{`v1`, ocfl.Spec{0, 0}, false},
-	{`1.0001`, ocfl.Spec{0, 0}, false},
-	{`01.1`, ocfl.Spec{0, 0}, false},
-	{`1.00`, ocfl.Spec{0, 0}, false},
-	{`0.0`, ocfl.Spec{0, 0}, false},
+	{`1.00`, ocfl.Spec(""), false},
+	{`10`, ocfl.Spec(""), false},
+	{`0`, ocfl.Spec(""), false},
+	{``, ocfl.Spec(""), false},
+	{`v1`, ocfl.Spec(""), false},
+	{`1.0001`, ocfl.Spec(""), false},
+	{`01.1`, ocfl.Spec(""), false},
+	{`1.00`, ocfl.Spec(""), false},
+	{`0.0`, ocfl.Spec(""), false},
 }
 
 func TestVersionParse(t *testing.T) {
 	is := is.New(t)
 	for _, t := range vNumTable {
-		v := ocfl.Spec{}
-		err := ocfl.ParseSpec(t.in, &v)
+		v, err := ocfl.ParseSpec(t.in)
 		if t.valid {
 			is.NoErr(err)
 		} else {
@@ -49,7 +46,7 @@ func TestVersionParse(t *testing.T) {
 }
 
 func TestCmp(t *testing.T) {
-	v1 := ocfl.MustParseSpec("2.2")
+	v1 := ocfl.Spec1_0
 	table := map[ocfl.Spec]int{
 		ocfl.MustParseSpec("2.0"): 1,
 		ocfl.MustParseSpec("1.0"): 1,
@@ -74,11 +71,11 @@ type invTypeTest struct {
 
 var invTypeTable = []invTypeTest{
 	// valid
-	{"https://ocfl.io/1.0/spec/#inventory", ocfl.Spec{1, 0}, true},
-	{"https://ocfl.io/1.1/spec/#inventory", ocfl.Spec{1, 1}, true},
+	{"https://ocfl.io/1.0/spec/#inventory", ocfl.Spec1_0, true},
+	{"https://ocfl.io/1.1/spec/#inventory", ocfl.Spec1_1, true},
 	// invalid
-	{"https://ocfl.io/1/spec/#inventory", ocfl.Spec{0, 0}, false},
-	{"https://ocfl.io/spec/#inventory", ocfl.Spec{0, 0}, false},
+	{"https://ocfl.io/1/spec/#inventory", ocfl.Spec(""), false},
+	{"https://ocfl.io/spec/#inventory", ocfl.Spec(""), false},
 }
 
 func TestParseInventoryType(t *testing.T) {
@@ -114,20 +111,20 @@ func TestWriteSpecFile(t *testing.T) {
 			t.Fatal("expected an error")
 		}
 	}
-	test(ocfl.Spec{1, 0})
-	test(ocfl.Spec{1, 1})
+	test(ocfl.Spec1_0)
+	test(ocfl.Spec1_1)
 	// expect an error
-	_, err := ocfl.WriteSpecFile(ctx, fsys, "dir1", ocfl.Spec{3, 0})
+	_, err := ocfl.WriteSpecFile(ctx, fsys, "dir1", ocfl.Spec("3.0"))
 	if err == nil {
 		t.Fatal("expected an error")
 	}
 }
 
 func TestSpecEmpty(t *testing.T) {
-	if !(ocfl.Spec{}).Empty() {
+	if !(ocfl.Spec("")).Empty() {
 		t.Error("empty spec value should be Empty()")
 	}
-	if (ocfl.Spec{1, 0}).Empty() {
+	if (ocfl.Spec1_0).Empty() {
 		t.Error("non-empty spec value should not be Empty()")
 	}
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -9,60 +9,6 @@ import (
 	"github.com/srerickson/ocfl-go/backend/memfs"
 )
 
-type vNumTest struct {
-	in    string
-	out   ocfl.Spec
-	valid bool
-}
-
-var vNumTable = []vNumTest{
-	// valid
-	{`1.0`, ocfl.Spec1_0, true},
-	{`1.1`, ocfl.Spec1_1, true},
-
-	// invalid
-	{`1.00`, ocfl.Spec(""), false},
-	{`10`, ocfl.Spec(""), false},
-	{`0`, ocfl.Spec(""), false},
-	{``, ocfl.Spec(""), false},
-	{`v1`, ocfl.Spec(""), false},
-	{`1.0001`, ocfl.Spec(""), false},
-	{`01.1`, ocfl.Spec(""), false},
-	{`1.00`, ocfl.Spec(""), false},
-	{`0.0`, ocfl.Spec(""), false},
-}
-
-func TestVersionParse(t *testing.T) {
-	is := is.New(t)
-	for _, t := range vNumTable {
-		v, err := ocfl.ParseSpec(t.in)
-		if t.valid {
-			is.NoErr(err)
-		} else {
-			is.True(err != nil)
-		}
-		is.Equal(v, t.out)
-	}
-}
-
-func TestCmp(t *testing.T) {
-	v1 := ocfl.Spec1_0
-	table := map[ocfl.Spec]int{
-		ocfl.MustParseSpec("2.0"): 1,
-		ocfl.MustParseSpec("1.0"): 1,
-		ocfl.MustParseSpec("2.2"): 0,
-		ocfl.MustParseSpec("2.3"): -1,
-		ocfl.MustParseSpec("3.2"): -1,
-	}
-
-	for v2, exp := range table {
-		got := v1.Cmp(v2)
-		if got != exp {
-			t.Errorf("comparing %s and %s: got %d, expected %d", v1, v2, got, exp)
-		}
-	}
-}
-
 type invTypeTest struct {
 	in    string
 	out   ocfl.Spec


### PR DESCRIPTION
- ocfl.Spec is just a string
- rename `ocfl.Declaration` to `ocfl.Namaste`
- simplify API for ocfl.Spec and ocfl.Namaste