### PR TITLE
ObjectRoot improvements

### DIFF
--- a/backend/cloud/cloud_test.go
+++ b/backend/cloud/cloud_test.go
@@ -132,7 +132,7 @@ func TestReadDir(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if v := obj.VersionDirs.Head(); v != ocfl.V(3) {
+		if v := obj.State.VersionDirs.Head(); v != ocfl.V(3) {
 			t.Errorf("expected readdir results to include v3, got %v", v)
 		}
 	})

--- a/backend/s3/example/list-objects/main.go
+++ b/backend/s3/example/list-objects/main.go
@@ -17,6 +17,12 @@ func main() {
 	ctx := context.Background()
 	bucket := flag.Arg(0)
 	prefix := flag.Arg(1)
+	if bucket == "" {
+		log.Fatal("missing arg: bucket name")
+	}
+	if prefix == "" {
+		log.Fatal("missing arg: prefix")
+	}
 	if err := run(ctx, bucket, prefix); err != nil {
 		log.Fatal(err)
 	}

--- a/backend/s3/fs_test.go
+++ b/backend/s3/fs_test.go
@@ -179,12 +179,12 @@ func TestReadDir(t *testing.T) {
 			expect: func(t *testing.T, entries []fs.DirEntry, err error) {
 				be.NilErr(t, err)
 				obj := ocfl.NewObjectRoot(nil, "", entries)
-				be.True(t, obj.HasNamaste())
-				be.True(t, obj.HasInventory())
-				be.True(t, obj.HasSidecar())
-				be.True(t, obj.HasVersionDir(ocfl.V(1)))
-				be.True(t, obj.HasExtensions())
-				be.Equal(t, 1, len(obj.VersionDirs))
+				be.True(t, obj.State.HasNamaste())
+				be.True(t, obj.State.HasInventory())
+				be.True(t, obj.State.HasSidecar())
+				be.True(t, obj.State.HasVersionDir(ocfl.V(1)))
+				be.True(t, obj.State.HasExtensions())
+				be.Equal(t, 1, len(obj.State.VersionDirs))
 			},
 		},
 	}
@@ -458,11 +458,11 @@ func TestObjectRoots(t *testing.T) {
 				obj := roots[0]
 				be.Nonzero(t, obj.FS)
 				be.Equal(t, ".", obj.Path)
-				be.Equal(t, "sha512", obj.SidecarAlg)
-				be.True(t, obj.HasInventory())
-				be.True(t, obj.HasSidecar())
-				be.True(t, obj.HasNamaste())
-				be.True(t, obj.HasExtensions())
+				be.Equal(t, "sha512", obj.State.SidecarAlg)
+				be.True(t, obj.State.HasInventory())
+				be.True(t, obj.State.HasSidecar())
+				be.True(t, obj.State.HasNamaste())
+				be.True(t, obj.State.HasExtensions())
 			},
 		}, {
 			desc: "complete object in subdir",
@@ -484,12 +484,12 @@ func TestObjectRoots(t *testing.T) {
 				obj := roots[0]
 				be.Nonzero(t, obj.FS)
 				be.Equal(t, "a/b", obj.Path)
-				be.Equal(t, "sha512", obj.SidecarAlg)
-				be.Equal(t, 2, len(obj.VersionDirs))
-				be.True(t, obj.HasInventory())
-				be.True(t, obj.HasSidecar())
-				be.True(t, obj.HasNamaste())
-				be.True(t, obj.HasExtensions())
+				be.Equal(t, "sha512", obj.State.SidecarAlg)
+				be.Equal(t, 2, len(obj.State.VersionDirs))
+				be.True(t, obj.State.HasInventory())
+				be.True(t, obj.State.HasSidecar())
+				be.True(t, obj.State.HasNamaste())
+				be.True(t, obj.State.HasExtensions())
 			},
 		}, {
 			desc: "full storage root",
@@ -503,14 +503,14 @@ func TestObjectRoots(t *testing.T) {
 				be.Equal(t, 2001, len(roots))
 				for _, obj := range roots {
 					be.Nonzero(t, obj.FS)
-					be.Equal(t, "sha512", obj.SidecarAlg)
-					be.True(t, obj.HasNamaste())
-					be.Equal(t, "1.1", string(obj.Spec))
-					be.True(t, obj.HasInventory())
-					be.True(t, obj.HasSidecar())
-					be.True(t, obj.HasNamaste())
-					be.True(t, obj.HasExtensions())
-					be.Equal(t, 1, len(obj.VersionDirs))
+					be.Equal(t, "sha512", obj.State.SidecarAlg)
+					be.True(t, obj.State.HasNamaste())
+					be.Equal(t, "1.1", string(obj.State.Spec))
+					be.True(t, obj.State.HasInventory())
+					be.True(t, obj.State.HasSidecar())
+					be.True(t, obj.State.HasNamaste())
+					be.True(t, obj.State.HasExtensions())
+					be.Equal(t, 1, len(obj.State.VersionDirs))
 				}
 
 			},
@@ -528,7 +528,7 @@ func TestObjectRoots(t *testing.T) {
 				be.NilErr(t, err)
 				be.Equal(t, 1, len(roots))
 				obj := roots[0]
-				be.Equal(t, "1.0", obj.Spec)
+				be.Equal(t, "1.0", obj.State.Spec)
 			},
 		}, {
 			desc: "ignore nested namaste",
@@ -544,7 +544,7 @@ func TestObjectRoots(t *testing.T) {
 				be.NilErr(t, err)
 				be.Equal(t, 1, len(roots))
 				obj := roots[0]
-				be.Equal(t, "1.0", obj.Spec)
+				be.Equal(t, "1.0", obj.State.Spec)
 			},
 		},
 		{
@@ -572,7 +572,7 @@ func TestObjectRoots(t *testing.T) {
 				be.NilErr(t, err)
 				be.Equal(t, 1, len(roots))
 				obj := roots[0]
-				be.Equal(t, 1, len(obj.NonConform))
+				be.Equal(t, 1, len(obj.State.NonConform))
 			},
 		},
 		{
@@ -589,7 +589,7 @@ func TestObjectRoots(t *testing.T) {
 				be.NilErr(t, err)
 				be.Equal(t, 1, len(roots))
 				obj := roots[0]
-				be.Equal(t, 1, len(obj.NonConform))
+				be.Equal(t, 1, len(obj.State.NonConform))
 			},
 		},
 	}

--- a/backend/s3/fs_test.go
+++ b/backend/s3/fs_test.go
@@ -178,7 +178,7 @@ func TestReadDir(t *testing.T) {
 			},
 			expect: func(t *testing.T, entries []fs.DirEntry, err error) {
 				be.NilErr(t, err)
-				state := ocfl.ParseObjectRootEntries(entries)
+				state := ocfl.ParseObjectRootDir(entries)
 				be.True(t, state.HasNamaste())
 				be.True(t, state.HasInventory())
 				be.True(t, state.HasSidecar())

--- a/backend/s3/fs_test.go
+++ b/backend/s3/fs_test.go
@@ -178,13 +178,13 @@ func TestReadDir(t *testing.T) {
 			},
 			expect: func(t *testing.T, entries []fs.DirEntry, err error) {
 				be.NilErr(t, err)
-				obj := ocfl.NewObjectRoot(nil, "", entries)
-				be.True(t, obj.State.HasNamaste())
-				be.True(t, obj.State.HasInventory())
-				be.True(t, obj.State.HasSidecar())
-				be.True(t, obj.State.HasVersionDir(ocfl.V(1)))
-				be.True(t, obj.State.HasExtensions())
-				be.Equal(t, 1, len(obj.State.VersionDirs))
+				state := ocfl.NewObjectRootState(entries)
+				be.True(t, state.HasNamaste())
+				be.True(t, state.HasInventory())
+				be.True(t, state.HasSidecar())
+				be.True(t, state.HasVersionDir(ocfl.V(1)))
+				be.True(t, state.HasExtensions())
+				be.Equal(t, 1, len(state.VersionDirs))
 			},
 		},
 	}

--- a/backend/s3/fs_test.go
+++ b/backend/s3/fs_test.go
@@ -178,7 +178,7 @@ func TestReadDir(t *testing.T) {
 			},
 			expect: func(t *testing.T, entries []fs.DirEntry, err error) {
 				be.NilErr(t, err)
-				state := ocfl.NewObjectRootState(entries)
+				state := ocfl.ParseObjectRootEntries(entries)
 				be.True(t, state.HasNamaste())
 				be.True(t, state.HasInventory())
 				be.True(t, state.HasSidecar())
@@ -572,7 +572,7 @@ func TestObjectRoots(t *testing.T) {
 				be.NilErr(t, err)
 				be.Equal(t, 1, len(roots))
 				obj := roots[0]
-				be.Equal(t, 1, len(obj.State.NonConform))
+				be.Equal(t, 1, len(obj.State.Invalid))
 			},
 		},
 		{
@@ -589,7 +589,7 @@ func TestObjectRoots(t *testing.T) {
 				be.NilErr(t, err)
 				be.Equal(t, 1, len(roots))
 				obj := roots[0]
-				be.Equal(t, 1, len(obj.State.NonConform))
+				be.Equal(t, 1, len(obj.State.Invalid))
 			},
 		},
 	}

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -350,10 +350,12 @@ func objectyRootsIter(ctx context.Context, api ObjectRootsAPI, buck string, fsys
 						}
 					}
 					obj = &ocfl.ObjectRoot{
-						FS:    fsys,
-						Path:  keyDir,
-						Spec:  decl.Version,
-						Flags: ocfl.HasNamaste,
+						FS:   fsys,
+						Path: keyDir,
+						State: &ocfl.ObjectRootState{
+							Spec:  decl.Version,
+							Flags: ocfl.HasNamaste,
+						},
 					}
 				case obj == nil || (obj.Path != "." && !strings.HasPrefix(key, obj.Path+"/")):
 					// ignore the key if its not part of an object that
@@ -366,12 +368,12 @@ func objectyRootsIter(ctx context.Context, api ObjectRootsAPI, buck string, fsys
 					// file in OCFL object root
 					switch {
 					case keyBase == "inventory.json":
-						obj.Flags |= ocfl.HasInventory
+						obj.State.Flags |= ocfl.HasInventory
 					case strings.HasPrefix(keyBase, "inventory.json."):
-						obj.Flags |= ocfl.HasSidecar
-						obj.SidecarAlg = strings.TrimPrefix(keyBase, "inventory.json.")
+						obj.State.Flags |= ocfl.HasSidecar
+						obj.State.SidecarAlg = strings.TrimPrefix(keyBase, "inventory.json.")
 					default:
-						obj.NonConform = append(obj.NonConform, keyBase)
+						obj.State.NonConform = append(obj.State.NonConform, keyBase)
 					}
 				default:
 					// subdirectory of OCFL object root
@@ -379,15 +381,15 @@ func objectyRootsIter(ctx context.Context, api ObjectRootsAPI, buck string, fsys
 					var vnum ocfl.VNum
 					switch {
 					case subdir == "extensions":
-						if !obj.HasExtensions() {
-							obj.Flags |= ocfl.HasExtensions
+						if !obj.State.HasExtensions() {
+							obj.State.Flags |= ocfl.HasExtensions
 						}
 					case ocfl.ParseVNum(subdir, &vnum) == nil:
-						if !slices.Contains(obj.VersionDirs, vnum) {
-							obj.VersionDirs = append(obj.VersionDirs, vnum)
+						if !slices.Contains(obj.State.VersionDirs, vnum) {
+							obj.State.VersionDirs = append(obj.State.VersionDirs, vnum)
 						}
 					default:
-						obj.NonConform = append(obj.NonConform, subdir)
+						obj.State.NonConform = append(obj.State.NonConform, subdir)
 					}
 				}
 			}

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -373,7 +373,7 @@ func objectyRootsIter(ctx context.Context, api ObjectRootsAPI, buck string, fsys
 						obj.State.Flags |= ocfl.HasSidecar
 						obj.State.SidecarAlg = strings.TrimPrefix(keyBase, "inventory.json.")
 					default:
-						obj.State.NonConform = append(obj.State.NonConform, keyBase)
+						obj.State.Invalid = append(obj.State.Invalid, keyBase)
 					}
 				default:
 					// subdirectory of OCFL object root
@@ -389,7 +389,7 @@ func objectyRootsIter(ctx context.Context, api ObjectRootsAPI, buck string, fsys
 							obj.State.VersionDirs = append(obj.State.VersionDirs, vnum)
 						}
 					default:
-						obj.State.NonConform = append(obj.State.NonConform, subdir)
+						obj.State.Invalid = append(obj.State.Invalid, subdir)
 					}
 				}
 			}

--- a/examples/listobjects/main.go
+++ b/examples/listobjects/main.go
@@ -1,26 +1,22 @@
 package main
 
-// lists IDs for all objects in a storage root
-
+// logs ids and paths for all objects in a storage root
 import (
 	"context"
 	"flag"
+	"log/slog"
 	"net/url"
 	"os"
 	"runtime"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/config"
+	awsS3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/srerickson/ocfl-go"
-	"github.com/srerickson/ocfl-go/backend/cloud"
+	"github.com/srerickson/ocfl-go/backend/s3"
+	"github.com/srerickson/ocfl-go/internal/pipeline"
 	"github.com/srerickson/ocfl-go/logging"
 	"github.com/srerickson/ocfl-go/ocflv1"
-	"gocloud.dev/blob"
-
-	// FIXME -- this import appears to be broken?
-	// _ "gocloud.dev/blob/azureblob"
-	"log/slog"
-
-	"golang.org/x/sync/errgroup"
 )
 
 var numgos int
@@ -31,14 +27,14 @@ func main() {
 	logger := logging.DefaultLogger()
 	flag.IntVar(&numgos, "gos", runtime.NumCPU(), "number of goroutines used for inventory downloading")
 	flag.Parse()
-	storeURI := flag.Arg(0)
-	if storeURI == "" {
+	storeConn := flag.Arg(0)
+	if storeConn == "" {
 		logger.Error("missing required storage root URI")
 		os.Exit(1)
 	}
-	fsys, dir, err := parseURI(ctx, storeURI)
+	fsys, dir, err := parseStoreConn(ctx, storeConn)
 	if err != nil {
-		logger.Error("can't parse storage root URI", "err", err)
+		logger.Error("can't parse storage root argument", "err", err)
 		os.Exit(1)
 	}
 	if err := listObjects(ctx, fsys, dir, numgos, logger); err != nil {
@@ -48,57 +44,55 @@ func main() {
 }
 
 func listObjects(ctx context.Context, fsys ocfl.FS, dir string, gos int, logger *slog.Logger) error {
-	// channel for passing object roots from iterator to concurrent inventory
-	// download workers
-	objRootChan := make(chan *ocfl.ObjectRoot)
-	defer close(objRootChan)
-
-	// errgroup for concurrent inventory downloads
-	group, ctx := errgroup.WithContext(ctx)
-	for i := 0; i < gos; i++ {
-		group.Go(func() error {
-			for objRoot := range objRootChan {
-				if err := ctx.Err(); err != nil {
-					return err
-				}
-				obj := ocflv1.Object{ObjectRoot: *objRoot}
-				if err := obj.SyncInventory(ctx); err != nil {
-					logger.Error("invalid object", "obj", *objRoot, "err", err)
-					return err
-				}
-				logger.Info(obj.Inventory.ID)
+	objectRoots := func(yield func(*ocfl.ObjectRoot) bool) {
+		ocfl.ObjectRoots(ctx, fsys, dir)(func(obj *ocfl.ObjectRoot, err error) bool {
+			if err != nil {
+				return false
 			}
-			return nil
+			return yield(obj)
 		})
-
 	}
-	var iterErr error
-	ocfl.ObjectRoots(ctx, fsys, dir)(func(obj *ocfl.ObjectRoot, err error) bool {
-		if err != nil {
-			iterErr = err
+	readInventories := func(root *ocfl.ObjectRoot) (*ocflv1.Object, error) {
+		obj := &ocflv1.Object{
+			ObjectRoot: *root,
+		}
+		if err := obj.SyncInventory(ctx); err != nil {
+			return nil, err
+		}
+		return obj, nil
+	}
+	var err error
+	resultIter := pipeline.Results(objectRoots, readInventories, gos)
+	resultIter(func(r pipeline.Result[*ocfl.ObjectRoot, *ocflv1.Object]) bool {
+		if r.Err != nil {
+			err = r.Err
 			return false
 		}
-		objRootChan <- obj
+		logger.Info("found object", "id", r.Out.Inventory.ID, "path", r.In.Path)
 		return true
 	})
-	return iterErr
+	return err
 }
 
-func parseURI(ctx context.Context, name string) (ocfl.FS, string, error) {
-	//if we were using cloud-based backend:
+func parseStoreConn(ctx context.Context, name string) (ocfl.FS, string, error) {
+	//if we were using s3-based backend:
 	rl, err := url.Parse(name)
 	if err != nil {
 		return nil, "", err
 	}
 	switch rl.Scheme {
-	case "azblob":
-		bucket, err := blob.OpenBucket(ctx, rl.Scheme+"://"+rl.Host)
+	case "s3":
+		cfg, err := config.LoadDefaultConfig(ctx)
 		if err != nil {
 			return nil, "", err
 		}
-		return cloud.NewFS(bucket, cloud.WithLogger(logging.DefaultLogger())), strings.TrimPrefix(rl.Path, "/"), nil
+		fsys := &s3.BucketFS{
+			S3:     awsS3.NewFromConfig(cfg),
+			Bucket: rl.Host,
+			Logger: logging.DefaultLogger(),
+		}
+		return fsys, strings.TrimPrefix(rl.Path, "/"), nil
 	default:
 		return ocfl.DirFS(name), ".", nil
 	}
-	// return ocfl.DirFS(name), ".", nil
 }

--- a/examples/listobjects/main.go
+++ b/examples/listobjects/main.go
@@ -48,7 +48,7 @@ func main() {
 	}
 }
 
-func listObjects(ctx context.Context, fsys ocfl.FS, dir string, gos int, logger *slog.Logger) error {
+func listObjects(ctx context.Context, fsys ocfl.FS, dir string, gos int, _ *slog.Logger) error {
 	objectRoots := func(yield func(*ocfl.ObjectRoot) bool) {
 		// with go 1.23, we should be able to write:
 		// for obj, err := range ocfl.ObjectRoots(...) {}
@@ -61,7 +61,7 @@ func listObjects(ctx context.Context, fsys ocfl.FS, dir string, gos int, logger 
 	}
 	getID := func(obj *ocfl.ObjectRoot) (inventory, error) {
 		var inv inventory
-		if err := obj.UnmarshalInventory(ctx, &inv); err != nil {
+		if err := obj.UnmarshalInventory(ctx, `.`, &inv); err != nil {
 			return inv, err
 		}
 		return inv, nil

--- a/namaste.go
+++ b/namaste.go
@@ -79,8 +79,8 @@ func ParseNamaste(name string) (n Namaste, err error) {
 	return n, nil
 }
 
-// ReadNamaste validates a namaste declaration
-func ReadNamaste(ctx context.Context, fsys FS, name string) error {
+// ValidateNamaste validates a namaste declaration
+func ValidateNamaste(ctx context.Context, fsys FS, name string) error {
 	d, err := ParseNamaste(path.Base(name))
 	if err != nil {
 		return err

--- a/namaste.go
+++ b/namaste.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	ErrNoNamaste       = fmt.Errorf("missing NAMASTE declaration: %w", fs.ErrNotExist)
+	ErrNamasteNotExist = fmt.Errorf("missing NAMASTE declaration: %w", fs.ErrNotExist)
 	ErrNamasteInvalid  = errors.New("invalid NAMASTE declaration contents")
 	ErrNamasteMultiple = errors.New("multiple NAMASTE declarations found")
 	namasteRE          = regexp.MustCompile(`^0=([a-z_]+)_([0-9]+\.[0-9]+)$`)
@@ -29,7 +29,7 @@ type Namaste struct {
 	Version Spec
 }
 
-// FindNamaste returns the Namasted declaration from a fs.DirEntry slice. An
+// FindNamaste returns the NAMASTE declaration from a fs.DirEntry slice. An
 // error is returned if the number of declarations is not one.
 func FindNamaste(items []fs.DirEntry) (Namaste, error) {
 	var found []Namaste
@@ -43,7 +43,7 @@ func FindNamaste(items []fs.DirEntry) (Namaste, error) {
 	}
 	switch len(found) {
 	case 0:
-		return Namaste{}, ErrNoNamaste
+		return Namaste{}, ErrNamasteNotExist
 	case 1:
 		return found[0], nil
 	default:
@@ -71,7 +71,7 @@ func (n Namaste) Body() string {
 func ParseNamaste(name string) (n Namaste, err error) {
 	m := namasteRE.FindStringSubmatch(name)
 	if len(m) != 3 {
-		err = ErrNoNamaste
+		err = ErrNamasteNotExist
 		return
 	}
 	n.Type = m[1]

--- a/namaste.go
+++ b/namaste.go
@@ -18,7 +18,7 @@ const (
 
 var (
 	ErrNamasteNotExist = fmt.Errorf("missing NAMASTE declaration: %w", fs.ErrNotExist)
-	ErrNamasteInvalid  = errors.New("invalid NAMASTE declaration contents")
+	ErrNamasteContents = errors.New("invalid NAMASTE declaration contents")
 	ErrNamasteMultiple = errors.New("multiple NAMASTE declarations found")
 	namasteRE          = regexp.MustCompile(`^0=([a-z_]+)_([0-9]+\.[0-9]+)$`)
 )
@@ -95,7 +95,7 @@ func ValidateNamaste(ctx context.Context, fsys FS, name string) error {
 		return fmt.Errorf("reading declaration: %w", err)
 	}
 	if string(decl) != d.Body() {
-		return ErrNamasteInvalid
+		return ErrNamasteContents
 	}
 	return nil
 }

--- a/namaste_test.go
+++ b/namaste_test.go
@@ -42,11 +42,11 @@ func TestValidate(t *testing.T) {
 		"1=hot_tub_12.1": &fstest.MapFile{
 			Data: []byte("hot_tub_12.1\n")},
 	}
-	err := ocfl.ReadNamaste(context.Background(), ocfl.NewFS(fsys), "0=hot_tub_12.1")
+	err := ocfl.ValidateNamaste(context.Background(), ocfl.NewFS(fsys), "0=hot_tub_12.1")
 	is.NoErr(err)
-	err = ocfl.ReadNamaste(context.Background(), ocfl.NewFS(fsys), "0=hot_bath_12.1")
+	err = ocfl.ValidateNamaste(context.Background(), ocfl.NewFS(fsys), "0=hot_bath_12.1")
 	is.True(err != nil)
-	err = ocfl.ReadNamaste(context.Background(), ocfl.NewFS(fsys), "1=hot_tub_12.1")
+	err = ocfl.ValidateNamaste(context.Background(), ocfl.NewFS(fsys), "1=hot_tub_12.1")
 	is.True(err != nil)
 }
 
@@ -64,6 +64,6 @@ func TestWriteDeclaration(t *testing.T) {
 	is.NoErr(err)
 	is.True(out.Type == "ocfl")
 	is.True(out.Version == v)
-	err = ocfl.ReadNamaste(ctx, fsys, dec.Name())
+	err = ocfl.ValidateNamaste(ctx, fsys, dec.Name())
 	is.NoErr(err)
 }

--- a/objectroot.go
+++ b/objectroot.go
@@ -114,16 +114,11 @@ func (obj ObjectRoot) ExtensionNames(ctx context.Context) ([]string, error) {
 	return names, err
 }
 
-// UnmarshalInventory unmarshals the object root's inventory.json file into the
-// value pointed to by v
-func (obj ObjectRoot) UnmarshalInventory(ctx context.Context, v any) error {
-	return obj.UnmarshalInventoryDir(ctx, `.`, v)
-}
-
-// UnmarshalInventoryDir unmarshals the inventory.json file in object root's
-// directory dir into the value pointed to by v. Set dir to `.` to unmarshal the
+// UnmarshalInventory unmarshals the inventory.json file in the object root's
+// sub-directory, dir, into the value pointed to by v. For example, set dir to
+// `v1` to unmarshall the object's v1 inventory. Set dir to `.` to unmarshal the
 // root inventory.
-func (obj ObjectRoot) UnmarshalInventoryDir(ctx context.Context, dir string, v any) error {
+func (obj ObjectRoot) UnmarshalInventory(ctx context.Context, dir string, v any) error {
 	name := inventoryFile
 	if dir != `.` {
 		name = dir + "/" + name

--- a/objectroot.go
+++ b/objectroot.go
@@ -10,16 +10,16 @@ import (
 )
 
 const (
-	// HasNamaste indicates a NAMASTE object declaration file exists in the
-	// object root directory
+	// HasNamaste indicates that an object root directory includes a NAMASTE
+	// object declaration file
 	HasNamaste objectRootFlag = 1 << iota
-	// HasInventory indicates that an ObjectRoot includes an "inventory.json"
+	// HasInventory indicates that an object root includes an "inventory.json"
 	// file
 	HasInventory
-	// HasSidecar indicates that an ObjectRoot includes an "inventory.json.*"
+	// HasSidecar indicates that an object root includes an "inventory.json.*"
 	// file (the inventory sidecar).
 	HasSidecar
-	// HasExtensions indicates that an ObjectRoot includes a directory
+	// HasExtensions indicates that an object root includes a directory
 	// named "extensions"
 	HasExtensions
 

--- a/objectroot.go
+++ b/objectroot.go
@@ -114,10 +114,21 @@ func (obj ObjectRoot) ExtensionNames(ctx context.Context) ([]string, error) {
 	return names, err
 }
 
-// UnmarshalInventory unmarshals the contents of the object root's
-// inventory.json file into the value pointed to by v.
+// UnmarshalInventory unmarshals the object root's inventory.json file into the
+// value pointed to by v
 func (obj ObjectRoot) UnmarshalInventory(ctx context.Context, v any) error {
-	f, err := obj.OpenFile(ctx, inventoryFile)
+	return obj.UnmarshalInventoryDir(ctx, `.`, v)
+}
+
+// UnmarshalInventoryDir unmarshals the inventory.json file in object root's
+// directory dir into the value pointed to by v. Set dir to `.` to unmarshal the
+// root inventory.
+func (obj ObjectRoot) UnmarshalInventoryDir(ctx context.Context, dir string, v any) error {
+	name := inventoryFile
+	if dir != `.` {
+		name = dir + "/" + name
+	}
+	f, err := obj.OpenFile(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -132,8 +143,8 @@ func (obj ObjectRoot) UnmarshalInventory(ctx context.Context, v any) error {
 // OpenFile opens a file using a name relative to the object root's path
 func (obj ObjectRoot) OpenFile(ctx context.Context, name string) (fs.File, error) {
 	if obj.Path != "." {
-		// not using path.Join because it would collapse path elements,
-		// potentially ignoring invalid values for obj.Path and name.
+		// using path.Join might hide potentially invalid values for
+		// obj.Path or name.
 		name = obj.Path + "/" + name
 	}
 	return obj.FS.OpenFile(ctx, name)

--- a/objectroot.go
+++ b/objectroot.go
@@ -92,6 +92,30 @@ func (obj ObjectRoot) ValidateNamaste(ctx context.Context) error {
 	return ValidateNamaste(ctx, obj.FS, decl)
 }
 
+// ExtensionNames returns the names of directories in the
+// object root's extensions directory.
+// func (obj ObjectRoot) ExtensionNames(ctx context.Context) ([]string, error) {
+// 	if obj.State != nil && !obj.State.HasExtensions() {
+// 		return nil, nil
+// 	}
+// 	entries, err := obj.FS.ReadDir(ctx, path.Join(obj.Path, ExtensionsDir))
+// 	if err != nil {
+// 		if errors.Is(err, fs.ErrNotExist) {
+// 			return nil, nil
+// 		}
+// 		return nil, err
+// 	}
+// 	names := make([]string, len(entries))
+// 	for _, e := range entries {
+// 		if !e.IsDir() {
+// 			// return error?
+// 			continue
+// 		}
+// 		names = append(names, e.Name())
+// 	}
+// 	return names, err
+// }
+
 // ObjectRootState represents the contents of an OCFL Object root directory.
 type ObjectRootState struct {
 	Spec        Spec           // the OCFL spec from the object's NAMASTE declaration file

--- a/objectroot.go
+++ b/objectroot.go
@@ -92,6 +92,9 @@ func (obj *ObjectRoot) ValidateNamaste(ctx context.Context) error {
 // is returned. If object root does not include an extensions directory both
 // return values are nil.
 func (obj ObjectRoot) ExtensionNames(ctx context.Context) ([]string, error) {
+	// state needs to be checked in order to differentiate between the case of
+	// of the object root not an existing (an error) and the extensions
+	// directory not existing (not an error).
 	if err := obj.checkState(ctx); err != nil {
 		return nil, err
 	}
@@ -102,7 +105,7 @@ func (obj ObjectRoot) ExtensionNames(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, len(entries))
+	names := make([]string, 0, len(entries))
 	for _, e := range entries {
 		if !e.IsDir() {
 			// if the extensions directory includes non-directory

--- a/objectroot_test.go
+++ b/objectroot_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,7 +18,8 @@ import (
 
 var warnObjects = filepath.Join(`testdata`, `object-fixtures`, `1.0`, `warn-objects`)
 
-func TestNewObjectRootState(t *testing.T) {
+func TestParseObjectRootEntries(t *testing.T) {
+	const objDecl = "0=ocfl_object_1.1"
 	type testCase struct {
 		input []fs.DirEntry
 		want  ocfl.ObjectRootState
@@ -31,23 +33,92 @@ func TestNewObjectRootState(t *testing.T) {
 			input: []fs.DirEntry{},
 			want:  ocfl.ObjectRootState{},
 		},
-		"single regular namaste": {
+		"regular namaste": {
 			input: []fs.DirEntry{
-				&dirEntry{name: "0=ocfl_object_1.1"},
+				&dirEntry{name: objDecl},
 			},
 			want: ocfl.ObjectRootState{
 				Spec:  ocfl.Spec1_1,
 				Flags: ocfl.HasNamaste,
 			},
 		},
+		"irregular namaste": {
+			input: []fs.DirEntry{
+				&dirEntry{name: objDecl, mode: fs.ModeIrregular},
+			},
+			want: ocfl.ObjectRootState{
+				Spec:  ocfl.Spec1_1,
+				Flags: ocfl.HasNamaste,
+			},
+		},
+		"symlink namaste": {
+			input: []fs.DirEntry{
+				&dirEntry{name: objDecl, mode: fs.ModeSymlink},
+			},
+			want: ocfl.ObjectRootState{
+				Invalid: []string{"0=ocfl_object_1.1"},
+			},
+		},
 	}
 	i := 0
 	for name, kase := range testCases {
-		t.Run(fmt.Sprintf("%d-%s", i, name), func(t *testing.T) {
-			got := ocfl.NewObjectRootState(kase.input)
+		t.Run(fmt.Sprintf("case %d %s", i, name), func(t *testing.T) {
+			got := ocfl.ParseObjectRootEntries(kase.input)
 			be.DeepEqual(t, kase.want, *got)
 		})
 		i++
+	}
+
+	// cases from fixtures
+	type testCaseFixture struct {
+		name string
+		want ocfl.ObjectRootState
+	}
+	fixtureDir := filepath.Join(`testdata`, `object-fixtures`, `1.0`)
+	fixtureCases := []testCaseFixture{
+		{
+			name: filepath.Join(`bad-objects`, `E001_extra_dir_in_root`),
+			want: ocfl.ObjectRootState{
+				Spec:        ocfl.Spec1_0,
+				SidecarAlg:  "sha512",
+				VersionDirs: []ocfl.VNum{ocfl.V(1)},
+				Flags:       ocfl.HasInventory | ocfl.HasSidecar | ocfl.HasNamaste,
+				Invalid:     []string{"extra_dir"},
+			},
+		}, {
+			name: filepath.Join(`bad-objects`, `E001_v2_file_in_root`),
+			want: ocfl.ObjectRootState{
+				Spec:        ocfl.Spec1_0,
+				SidecarAlg:  "sha512",
+				VersionDirs: []ocfl.VNum{ocfl.V(1)},
+				Flags:       ocfl.HasInventory | ocfl.HasSidecar | ocfl.HasNamaste,
+				Invalid:     []string{"v2"},
+			},
+		}, {
+			name: filepath.Join(`warn-objects`, `W013_unregistered_extension`),
+			want: ocfl.ObjectRootState{
+				Spec:        ocfl.Spec1_0,
+				SidecarAlg:  "sha512",
+				VersionDirs: []ocfl.VNum{ocfl.V(1)},
+				Flags:       ocfl.HasInventory | ocfl.HasSidecar | ocfl.HasNamaste | ocfl.HasExtensions,
+			},
+		}, {
+			name: filepath.Join(`bad-objects`, `E058_no_sidecar`),
+			want: ocfl.ObjectRootState{
+				Spec:        ocfl.Spec1_0,
+				SidecarAlg:  "",
+				VersionDirs: []ocfl.VNum{ocfl.V(1)},
+				Flags:       ocfl.HasInventory | ocfl.HasNamaste,
+			},
+		},
+	}
+	for _, fixCase := range fixtureCases {
+		t.Run(fmt.Sprintf("fixture %s", fixCase.name), func(t *testing.T) {
+			entries, err := os.ReadDir(filepath.Join(fixtureDir, fixCase.name))
+			be.NilErr(t, err)
+			got := ocfl.ParseObjectRootEntries(entries)
+			be.DeepEqual(t, fixCase.want, *got)
+		})
 	}
 }
 
@@ -111,12 +182,12 @@ func TestObjectRoots(t *testing.T) {
 
 type dirEntry struct {
 	name string
-	typ  fs.FileMode
+	mode fs.FileMode
 }
 
 func (d dirEntry) Name() string      { return d.name }
-func (d dirEntry) IsDir() bool       { return d.typ.IsDir() }
-func (d dirEntry) Type() fs.FileMode { return d.typ.Type() }
+func (d dirEntry) IsDir() bool       { return d.mode.IsDir() }
+func (d dirEntry) Type() fs.FileMode { return d.mode.Type() }
 func (d dirEntry) Info() (fs.FileInfo, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/objectroot_test.go
+++ b/objectroot_test.go
@@ -38,27 +38,27 @@ func TestObjectRoots(t *testing.T) {
 					return false
 				}
 				numobjs++
-				if obj.SidecarAlg == "" {
+				if obj.State.SidecarAlg == "" {
 					t.Error("algorithm not set for", obj.Path)
 				}
-				if !obj.HasInventory() {
+				if !obj.State.HasInventory() {
 					t.Error("HasInventory false for", obj.Path)
 				}
-				if !obj.HasSidecar() {
+				if !obj.State.HasSidecar() {
 					t.Error("HasSidecar false for", obj.Path)
 				}
-				if err := obj.VersionDirs.Valid(); err != nil {
+				if err := obj.State.VersionDirs.Valid(); err != nil {
 					t.Error("version dirs not valid for", obj.Path)
 				}
 				v3Fixture := "w001_zero_padded_versions"
 				if strings.HasSuffix(obj.Path, v3Fixture) {
-					if len(obj.VersionDirs) != 3 {
+					if len(obj.State.VersionDirs) != 3 {
 						t.Error(obj.Path, "should have 3 versions")
 					}
 				}
 				extFixture := "W013_unregistered_extension"
 				if strings.HasSuffix(obj.Path, extFixture) {
-					if obj.Flags&ocfl.HasExtensions == 0 {
+					if obj.State.Flags&ocfl.HasExtensions == 0 {
 						t.Errorf(obj.Path, "should have extensions flag")
 					}
 				}

--- a/ocflv1/commit_test.go
+++ b/ocflv1/commit_test.go
@@ -34,7 +34,7 @@ func TestCommit(t *testing.T) {
 		if err := result.Err(); err != nil {
 			t.Fatal(err)
 		}
-		if alg != obj.SidecarAlg {
+		if alg != obj.State.SidecarAlg {
 			t.Fatal("expected digest to be", alg)
 		}
 		if obj.Path != root {

--- a/ocflv1/object.go
+++ b/ocflv1/object.go
@@ -73,6 +73,7 @@ func (obj *Object) Validate(ctx context.Context, opts ...ValidationOption) *vali
 	return r
 }
 
+// Stage returns an ocfl.Stage based on the specified version index.
 func (obj *Object) Stage(i int) (*ocfl.Stage, error) {
 	version := obj.Inventory.Version(i)
 	if version == nil {

--- a/ocflv1/object.go
+++ b/ocflv1/object.go
@@ -36,10 +36,10 @@ func GetObject(ctx context.Context, fsys ocfl.FS, dir string) (*Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !ocflVerSupported[root.Spec] {
-		return nil, fmt.Errorf("%s: %w", root.Spec, ErrOCFLVersion)
+	if !ocflVerSupported[root.State.Spec] {
+		return nil, fmt.Errorf("%s: %w", root.State.Spec, ErrOCFLVersion)
 	}
-	if !root.HasInventory() {
+	if !root.State.HasInventory() {
 		// what is the best error to use here?
 		return nil, ErrInventoryNotExist
 	}

--- a/ocflv1/object_validation.go
+++ b/ocflv1/object_validation.go
@@ -107,7 +107,7 @@ func (vldr *objectValidator) validateRoot(ctx context.Context) error {
 		err = ec(err, codes.E007.Ref(ocflV))
 		vldr.LogFatal(lgr, err)
 	}
-	for _, name := range vldr.root.State.NonConform {
+	for _, name := range vldr.root.State.Invalid {
 		err := fmt.Errorf(`%w: %s`, ErrObjRootStructure, name)
 		vldr.LogFatal(lgr, ec(err, codes.E001.Ref(ocflV)))
 	}

--- a/ocflv1/object_validation.go
+++ b/ocflv1/object_validation.go
@@ -55,7 +55,7 @@ func (vldr *objectValidator) validate(ctx context.Context) *validation.Result {
 		return vldr.LogFatal(lgr, err)
 	}
 	vldr.root = obj
-	ocflV := vldr.root.Spec
+	ocflV := vldr.root.State.Spec
 	switch ocflV {
 	case ocfl.Spec1_0:
 		fallthrough
@@ -63,7 +63,7 @@ func (vldr *objectValidator) validate(ctx context.Context) *validation.Result {
 		if err := vldr.validateRoot(ctx); err != nil {
 			return vldr.Result
 		}
-		for _, vnum := range vldr.root.VersionDirs {
+		for _, vnum := range vldr.root.State.VersionDirs {
 			if err := vldr.validateVersion(ctx, vnum); err != nil {
 				return vldr.Result
 			}
@@ -101,25 +101,25 @@ func (vldr *objectValidator) validate(ctx context.Context) *validation.Result {
 
 // validateRoot fully validates the object root contents
 func (vldr *objectValidator) validateRoot(ctx context.Context) error {
-	ocflV := vldr.root.Spec
+	ocflV := vldr.root.State.Spec
 	lgr := vldr.opts.Logger
 	if err := vldr.root.ValidateNamaste(ctx); err != nil {
 		err = ec(err, codes.E007.Ref(ocflV))
 		vldr.LogFatal(lgr, err)
 	}
-	for _, name := range vldr.root.NonConform {
+	for _, name := range vldr.root.State.NonConform {
 		err := fmt.Errorf(`%w: %s`, ErrObjRootStructure, name)
 		vldr.LogFatal(lgr, ec(err, codes.E001.Ref(ocflV)))
 	}
-	if !vldr.root.HasInventory() {
+	if !vldr.root.State.HasInventory() {
 		err := fmt.Errorf(`%w: not found`, ErrInventoryNotExist)
 		vldr.LogFatal(lgr, ec(err, codes.E063.Ref(ocflV)))
 	}
-	if !vldr.root.HasSidecar() {
+	if !vldr.root.State.HasSidecar() {
 		err := fmt.Errorf(`inventory sidecar: %w`, fs.ErrNotExist)
 		vldr.LogFatal(lgr, ec(err, codes.E058.Ref(ocflV)))
 	}
-	err := vldr.root.VersionDirs.Valid()
+	err := vldr.root.State.VersionDirs.Valid()
 	if err != nil {
 		if errors.Is(err, ocfl.ErrVerEmpty) {
 			err = ec(err, codes.E008.Ref(ocflV))
@@ -130,7 +130,7 @@ func (vldr *objectValidator) validateRoot(ctx context.Context) error {
 		}
 		vldr.LogFatal(lgr, err)
 	}
-	if err == nil && vldr.root.VersionDirs.Padding() > 0 {
+	if err == nil && vldr.root.State.VersionDirs.Padding() > 0 {
 		err := errors.New("version directory names are zero-padded")
 		vldr.LogWarn(lgr, ec(err, codes.W001.Ref(ocflV)))
 	}
@@ -138,7 +138,7 @@ func (vldr *objectValidator) validateRoot(ctx context.Context) error {
 }
 
 // func (vldr *objectValidator) validateNamaste(ctx context.Context) error {
-// 	ocflV := vldr.root.Spec
+// 	ocflV := vldr.root.State.Spec
 // 	lgr := vldr.opts.Logger
 // 	if vldr.rootInfo.Declaration.Type != ocfl.DeclObject {
 // 		err := fmt.Errorf("%w: %s", ErrOCFLVersion, ocflV)
@@ -153,13 +153,13 @@ func (vldr *objectValidator) validateRoot(ctx context.Context) error {
 // }
 
 func (vldr *objectValidator) validateRootInventory(ctx context.Context) error {
-	ocflV := vldr.root.Spec
+	ocflV := vldr.root.State.Spec
 	lgr := vldr.opts.Logger
 	name := path.Join(vldr.Root, inventoryFile)
 	opts := []ValidationOption{
 		copyValidationOptions(vldr.opts),
 		appendResult(vldr.Result),
-		FallbackOCFL(vldr.root.Spec),
+		FallbackOCFL(vldr.root.State.Spec),
 	}
 	if lgr != nil {
 		opts = append(opts, ValidationLogger(lgr.With("inventory_file", name)))
@@ -169,7 +169,7 @@ func (vldr *objectValidator) validateRootInventory(ctx context.Context) error {
 		return err
 	}
 	// Inventory head/versions are consitent with Object Root
-	if expHead := vldr.root.VersionDirs.Head(); expHead != inv.Head {
+	if expHead := vldr.root.State.VersionDirs.Head(); expHead != inv.Head {
 		vldr.LogFatal(lgr, ec(fmt.Errorf("inventory head is not %s", expHead), codes.E040.Ref(inv.Type.Spec)))
 		vldr.LogFatal(lgr, ec(fmt.Errorf("inventory versions don't include %s", expHead), codes.E046.Ref(inv.Type.Spec)))
 	}
@@ -191,7 +191,7 @@ func (vldr *objectValidator) validateRootInventory(ctx context.Context) error {
 }
 
 func (vldr *objectValidator) validateVersion(ctx context.Context, ver ocfl.VNum) error {
-	ocflV := vldr.root.Spec // assumed ocfl version (until inventory is decoded)
+	ocflV := vldr.root.State.Spec // assumed ocfl version (until inventory is decoded)
 	lgr := vldr.opts.Logger
 	if lgr != nil {
 		lgr = lgr.With("version", ver.String())
@@ -247,7 +247,7 @@ func (vldr *objectValidator) validateVersionInventory(ctx context.Context, vn oc
 	opts := []ValidationOption{
 		copyValidationOptions(vldr.opts),
 		appendResult(vldr.Result),
-		FallbackOCFL(vldr.root.Spec),
+		FallbackOCFL(vldr.root.State.Spec),
 	}
 	if lgr != nil {
 		opts = append(opts, ValidationLogger(lgr.With("inventory_file", name)))
@@ -322,7 +322,7 @@ func (vldr *objectValidator) validateExtensionsDir(ctx context.Context) error {
 	if lgr != nil {
 		lgr = lgr.With("dir", extensionsDir)
 	}
-	ocflV := vldr.root.Spec
+	ocflV := vldr.root.State.Spec
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
@@ -353,7 +353,7 @@ func (vldr *objectValidator) validateExtensionsDir(ctx context.Context) error {
 // exists in version inventory manifests equal of greater than the version in
 // which the path is stored, (4) all digests for all paths are confirmed.
 func (vldr *objectValidator) validatePathLedger(ctx context.Context) error {
-	ocflV := vldr.root.Spec
+	ocflV := vldr.root.State.Spec
 	lgr := vldr.opts.Logger
 	// check paths exist are in included in manifsts as necessary
 	for p, pInfo := range vldr.ledger.paths {

--- a/ocflv1/store.go
+++ b/ocflv1/store.go
@@ -128,7 +128,7 @@ func GetStore(ctx context.Context, fsys ocfl.FS, root string) (*Store, error) {
 		break
 	}
 	if ocflVer.Empty() {
-		return nil, fmt.Errorf("missing storage root declaration: %w", ocfl.ErrNoNamaste)
+		return nil, fmt.Errorf("missing storage root declaration: %w", ocfl.ErrNamasteNotExist)
 	}
 	str := &Store{
 		fsys:    fsys,

--- a/ocflv1/store.go
+++ b/ocflv1/store.go
@@ -118,7 +118,7 @@ func GetStore(ctx context.Context, fsys ocfl.FS, root string) (*Store, error) {
 	var ocflVer ocfl.Spec
 	for _, s := range []ocfl.Spec{ocflv1_1, ocflv1_0} {
 		decl := ocfl.Namaste{Type: ocfl.NamasteTypeStore, Version: s}.Name()
-		if err := ocfl.ReadNamaste(ctx, fsys, path.Join(root, decl)); err != nil {
+		if err := ocfl.ValidateNamaste(ctx, fsys, path.Join(root, decl)); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}

--- a/ocflv1/store_validation.go
+++ b/ocflv1/store_validation.go
@@ -171,7 +171,7 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 			objRoot := &ocfl.ObjectRoot{
 				FS:    fsys,
 				Path:  name,
-				State: ocfl.NewObjectRootState(entries),
+				State: ocfl.ParseObjectRootEntries(entries),
 			}
 			validateObjectRoot(objRoot)
 			return walkdirs.ErrSkipDirs // don't continue scan further into the object

--- a/ocflv1/store_validation.go
+++ b/ocflv1/store_validation.go
@@ -168,7 +168,11 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 		decl, _ := ocfl.FindNamaste(entries)
 		switch decl.Type {
 		case ocfl.NamasteTypeObject:
-			objRoot := ocfl.NewObjectRoot(fsys, name, entries)
+			objRoot := &ocfl.ObjectRoot{
+				FS:    fsys,
+				Path:  name,
+				State: ocfl.NewObjectRootState(entries),
+			}
 			validateObjectRoot(objRoot)
 			return walkdirs.ErrSkipDirs // don't continue scan further into the object
 		case ocfl.NamasteTypeStore:

--- a/ocflv1/store_validation.go
+++ b/ocflv1/store_validation.go
@@ -171,7 +171,7 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 			objRoot := &ocfl.ObjectRoot{
 				FS:    fsys,
 				Path:  name,
-				State: ocfl.ParseObjectRootEntries(entries),
+				State: ocfl.ParseObjectRootDir(entries),
 			}
 			validateObjectRoot(objRoot)
 			return walkdirs.ErrSkipDirs // don't continue scan further into the object

--- a/ocflv1/store_validation.go
+++ b/ocflv1/store_validation.go
@@ -129,7 +129,7 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 		if objLgr != nil {
 			objLgr = objLgr.With("object_path", objRoot.Path)
 		}
-		if ocflV.Cmp(objRoot.Spec) < 0 {
+		if ocflV.Cmp(objRoot.State.Spec) < 0 {
 			// object ocfl spec is higher than storage root's
 			result.LogFatal(objLgr, ErrObjectVersion)
 		}

--- a/ocflv1/store_validation.go
+++ b/ocflv1/store_validation.go
@@ -44,7 +44,7 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 	//NAMASTE specification.
 	//E080: The text contents of [the OCFL version declaration file] MUST be
 	//the same as dvalue, followed by a newline (\n).
-	err = ocfl.ReadNamaste(ctx, fsys, path.Join(root, decl.Name()))
+	err = ocfl.ValidateNamaste(ctx, fsys, path.Join(root, decl.Name()))
 	if err != nil {
 		result.LogFatal(lgr, ec(err, codes.E080.Ref(ocflV)))
 	}


### PR DESCRIPTION
changes to`ocfl.ObjectRoot`:
- new `ocfl.ObjectRootState` used for object root directory attributes.
- new method `ExtensionNames()` lists directories in `extensions`
- new methods `OpenFile()` and `ReadDir` for accessing files and directories using names relative to the object root
- new method `UnmarshalInventory()` for unmarshalling the inventory json
- improved tests
- cleanup `listobjects` example