### PR TITLE
Support Extended Digest Algorithms

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/go:1.3.0-1.23-bookworm
+# RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+# RUN apt-get update && apt-get upgrade -y && apt-get install -y goreleaser

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"dockerComposeFile": "docker-compose.yml",
+    "service": "devcontainer",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+}
+

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  devcontainer:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/workspaces:cached      
+    network_mode: service:minio
+    command: sleep infinity
+    environment:
+      AWS_ACCESS_KEY_ID: ocfltest
+      AWS_SECRET_ACCESS_KEY: ocfltest
+      AWS_REGION: us-east-1
+      OCFL_TEST_S3: "http://minio:9000"
+
+  minio:
+    image: quay.io/minio/minio:RELEASE.2024-09-22T00-33-43Z
+    restart: unless-stopped
+    volumes:
+      - minio-data:/data
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: ocfltest
+      MINIO_ROOT_PASSWORD: ocfltest
+
+volumes:
+  minio-data:

--- a/digest.go
+++ b/digest.go
@@ -16,21 +16,21 @@ import (
 // set to runtime.NumCPU(). The pathAlgs argument is an iterator that yields
 // file paths and a slice of digest algorithms. It returns an iteratator the
 // yields PathDigest or an error.
-func Digest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, []string]) iter.Seq2[PathDigests, error] {
+func Digest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, []digest.Algorithm]) iter.Seq2[PathDigests, error] {
 	return ConcurrentDigest(ctx, fsys, pathAlgs, runtime.NumCPU())
 }
 
 // ConcurrentDigest concurrently digests files in an FS. The pathAlgs argument
 // is an iterator that yields file paths and a slice of digest algorithms. It
 // returns an iteratator the yields PathDigest or an error.
-func ConcurrentDigest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, []string], numWorkers int) iter.Seq2[PathDigests, error] {
+func ConcurrentDigest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, []digest.Algorithm], numWorkers int) iter.Seq2[PathDigests, error] {
 	// checksum digestJob
 	type digestJob struct {
 		path string
-		algs []string
+		algs []digest.Algorithm
 	}
 	jobsIter := func(yield func(digestJob) bool) {
-		pathAlgs(func(name string, algs []string) bool {
+		pathAlgs(func(name string, algs []digest.Algorithm) bool {
 			return yield(digestJob{path: name, algs: algs})
 		})
 	}

--- a/digest.go
+++ b/digest.go
@@ -3,131 +3,14 @@ package ocfl
 import (
 	"context"
 	"errors"
-	"fmt"
-	"hash"
 	"io"
 	"iter"
 	"path"
 	"runtime"
-	"strings"
 
 	"github.com/srerickson/ocfl-go/digest"
 	"github.com/srerickson/ocfl-go/internal/pipeline"
-	"golang.org/x/crypto/blake2b"
 )
-
-// MultiDigester is used to generate digests for multiple digest algorithms at
-// the same time.
-type MultiDigester struct {
-	io.Writer
-	digesters map[string]digest.Digester
-}
-
-func NewMultiDigester(algs ...string) *MultiDigester {
-	writers := make([]io.Writer, 0, len(algs))
-	digesters := make(map[string]digest.Digester, len(algs))
-	for _, algID := range algs {
-		alg, _ := digest.Defaults.New(algID)
-		if alg == nil {
-			continue
-		}
-		digester := alg.Digester()
-		digesters[alg.ID()] = digester
-		writers = append(writers, digester)
-	}
-	if len(writers) == 0 {
-		return &MultiDigester{Writer: io.Discard}
-	}
-	return &MultiDigester{
-		Writer:    io.MultiWriter(writers...),
-		digesters: digesters,
-	}
-}
-
-func (md MultiDigester) Sum(alg string) string {
-	if dig := md.digesters[alg]; dig != nil {
-		return dig.String()
-	}
-	return ""
-}
-
-// Sums returns a DigestSet with all digest values
-// for the MultiDigester
-func (md MultiDigester) Sums() DigestSet {
-	set := make(DigestSet, len(md.digesters))
-	for alg, digester := range md.digesters {
-		set[alg] = digester.String()
-	}
-	return set
-}
-
-// Set is a set of digest results
-type DigestSet map[string]string
-
-func (s DigestSet) Add(s2 DigestSet) error {
-	for alg, newDigest := range s2 {
-		currDigest := s[alg]
-		if currDigest == "" {
-			s[alg] = newDigest
-			continue
-		}
-		if strings.EqualFold(currDigest, newDigest) {
-			continue
-		}
-		// digest conflict
-		return &DigestError{
-			Alg:      alg,
-			Got:      newDigest,
-			Expected: currDigest,
-		}
-	}
-	return nil
-}
-
-// ConflictWith returns keys in s with values that do not match the corresponding
-// key in other.
-func (s DigestSet) ConflictWith(other DigestSet) []string {
-	var keys []string
-	for alg, sv := range s {
-		if ov, ok := other[alg]; ok && !strings.EqualFold(sv, ov) {
-			keys = append(keys, alg)
-		}
-	}
-	return keys
-}
-
-// Validate digests reader and return an error if the resulting digest for any
-// algorithm in s doesn't match the value in s.
-func (s DigestSet) Validate(reader io.Reader) error {
-	algs := make([]string, 0, len(s))
-	for alg := range s {
-		algs = append(algs, alg)
-	}
-	digester := NewMultiDigester(algs...)
-	if _, err := io.Copy(digester, reader); err != nil {
-		return err
-	}
-	result := digester.Sums()
-	for _, alg := range result.ConflictWith(s) {
-		return &DigestError{Alg: alg, Expected: s[alg], Got: result[alg]}
-	}
-	return nil
-}
-
-// DigestError is returned when content's digest conflicts with an expected value
-type DigestError struct {
-	Path     string // Content path
-	Alg      string // Digest algorithm
-	Got      string // Calculated digest
-	Expected string // Expected digest
-}
-
-func (e DigestError) Error() string {
-	if e.Path == "" {
-		return fmt.Sprintf("unexpected %s value: %q, expected=%q", e.Alg, e.Got, e.Expected)
-	}
-	return fmt.Sprintf("unexpected %s for %q: %q, expected=%q", e.Alg, e.Path, e.Got, e.Expected)
-}
 
 // Digest is equivalent to ConcurrentDigest with the number of digest workers
 // set to runtime.NumCPU(). The pathAlgs argument is an iterator that yields
@@ -151,7 +34,7 @@ func ConcurrentDigest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, [
 			return yield(digestJob{path: name, algs: algs})
 		})
 	}
-	runJobs := func(j digestJob) (digests DigestSet, err error) {
+	runJobs := func(j digestJob) (digests digest.Set, err error) {
 		f, err := fsys.OpenFile(ctx, j.path)
 		if err != nil {
 			return
@@ -161,7 +44,7 @@ func ConcurrentDigest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, [
 				err = errors.Join(err, closeErr)
 			}
 		}()
-		digester := NewMultiDigester(j.algs...)
+		digester := digest.NewMultiDigester(j.algs...)
 		if _, err = io.Copy(digester, f); err != nil {
 			return
 		}
@@ -185,7 +68,7 @@ func ConcurrentDigest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, [
 // digests for a file in an FS.
 type PathDigests struct {
 	Path    string
-	Digests DigestSet
+	Digests digest.Set
 }
 
 // Validate validates pd's DigestSet by reading the file at pd.Path, relative to
@@ -199,19 +82,11 @@ func (pd PathDigests) Validate(ctx context.Context, fsys FS, parent string) (boo
 	}
 	if err := pd.Digests.Validate(f); err != nil {
 		f.Close()
-		var digestErr *DigestError
+		var digestErr *digest.DigestError
 		if errors.As(err, &digestErr) {
 			digestErr.Path = pd.Path
 		}
 		return false, err
 	}
 	return true, f.Close()
-}
-
-func mustBlake2bNew512() hash.Hash {
-	h, err := blake2b.New512(nil)
-	if err != nil {
-		panic("creating new blake2b hash")
-	}
-	return h
 }

--- a/digest.go
+++ b/digest.go
@@ -44,10 +44,7 @@ func ConcurrentDigest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, [
 				err = errors.Join(err, closeErr)
 			}
 		}()
-		digester, err := digest.NewMultiDigester(j.algs...)
-		if err != nil {
-			return
-		}
+		digester := digest.NewMultiDigester(j.algs...)
 		if _, err = io.Copy(digester, f); err != nil {
 			return
 		}

--- a/digest.go
+++ b/digest.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"iter"
-	"path"
 	"runtime"
 
 	"github.com/srerickson/ocfl-go/digest"
@@ -69,24 +68,4 @@ func ConcurrentDigest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, [
 type PathDigests struct {
 	Path    string
 	Digests digest.Set
-}
-
-// Validate validates pd's DigestSet by reading the file at pd.Path, relative to
-// the directory parent in fsys. The returned bool is true if the file was read
-// and all digests validated; in this case, the returned error may be non-nil if
-// error occured closing the file.
-func (pd PathDigests) Validate(ctx context.Context, fsys FS, parent string) (bool, error) {
-	f, err := fsys.OpenFile(ctx, path.Join(parent, pd.Path))
-	if err != nil {
-		return false, err
-	}
-	if err := pd.Digests.Validate(f); err != nil {
-		f.Close()
-		var digestErr *digest.DigestError
-		if errors.As(err, &digestErr) {
-			digestErr.Path = pd.Path
-		}
-		return false, err
-	}
-	return true, f.Close()
 }

--- a/digest.go
+++ b/digest.go
@@ -44,7 +44,10 @@ func ConcurrentDigest(ctx context.Context, fsys FS, pathAlgs iter.Seq2[string, [
 				err = errors.Join(err, closeErr)
 			}
 		}()
-		digester := digest.NewMultiDigester(j.algs...)
+		digester, err := digest.NewMultiDigester(j.algs...)
+		if err != nil {
+			return
+		}
 		if _, err = io.Copy(digester, f); err != nil {
 			return
 		}

--- a/digest/alg.go
+++ b/digest/alg.go
@@ -7,21 +7,21 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"hash"
-	"io"
 
 	"golang.org/x/crypto/blake2b"
 )
 
 const (
-	SHA512  = alg(`sha512`)
-	SHA256  = alg(`sha256`)
-	SHA1    = alg(`sha1`)
-	MD5     = alg(`md5`)
-	BLAKE2B = alg(`blake2b-512`)
+	SHA512  = alg(`sha512`)      // built-in Alg for sha512
+	SHA256  = alg(`sha256`)      // built-in Alg for sha256
+	SHA1    = alg(`sha1`)        // built-in Alg for sha1
+	MD5     = alg(`md5`)         // built-in Alg for md5
+	BLAKE2B = alg(`blake2b-512`) // built-in Alg for blake2b
 )
 
 var (
-	builtin = []Alg{SHA512, SHA256, SHA1, MD5, BLAKE2B}
+	// built-in Alg register
+	builtinRegister = NewRegister(SHA512, SHA256, SHA1, MD5, BLAKE2B)
 
 	// digester constructors for built-in algs
 	builtInDigesters = map[alg]func() Digester{
@@ -39,13 +39,6 @@ type Alg interface {
 	ID() string
 	// Digester returns a new digester for generating a new digest value
 	Digester() Digester
-}
-
-// Digester is an interface used for generating digest values.
-type Digester interface {
-	io.Writer
-	// String() returns the digest value for the bytes written to the digester.
-	String() string
 }
 
 // alg is a built-in Alg

--- a/digest/alg.go
+++ b/digest/alg.go
@@ -19,8 +19,8 @@ const (
 	BLAKE2B = alg(`blake2b-512`) // built-in Alg for blake2b-512
 )
 
-// Alg is implemented by digest algorithms
-type Alg interface {
+// Algorithm is implemented by digest algorithms
+type Algorithm interface {
 	// ID returns the algorithm name (e.g., 'sha512')
 	ID() string
 	// Digester returns a new digester for generating a new digest value

--- a/digest/alg.go
+++ b/digest/alg.go
@@ -16,7 +16,7 @@ const (
 	SHA256  = alg(`sha256`)      // built-in Alg for sha256
 	SHA1    = alg(`sha1`)        // built-in Alg for sha1
 	MD5     = alg(`md5`)         // built-in Alg for md5
-	BLAKE2B = alg(`blake2b-512`) // built-in Alg for blake2b
+	BLAKE2B = alg(`blake2b-512`) // built-in Alg for blake2b-512
 )
 
 // Alg is implemented by digest algorithms

--- a/digest/alg.go
+++ b/digest/alg.go
@@ -1,0 +1,75 @@
+package digest
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"hash"
+	"io"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+const (
+	SHA512  = alg(`sha512`)
+	SHA256  = alg(`sha256`)
+	SHA1    = alg(`sha1`)
+	MD5     = alg(`md5`)
+	BLAKE2B = alg(`blake2b-512`)
+)
+
+var (
+	builtin = []Alg{SHA512, SHA256, SHA1, MD5, BLAKE2B}
+
+	// digester constructors for built-in algs
+	builtInDigesters = map[alg]func() Digester{
+		SHA512:  func() Digester { return &hashDigester{Hash: sha512.New()} },
+		SHA256:  func() Digester { return &hashDigester{Hash: sha256.New()} },
+		SHA1:    func() Digester { return &hashDigester{Hash: sha1.New()} },
+		MD5:     func() Digester { return &hashDigester{Hash: md5.New()} },
+		BLAKE2B: func() Digester { return &hashDigester{Hash: mustBlake2bNew512()} },
+	}
+)
+
+// Alg is implemented by digest algorithms
+type Alg interface {
+	// ID returns the algorithm name (e.g., 'sha512')
+	ID() string
+	// Digester returns a new digester for generating a new digest value
+	Digester() Digester
+}
+
+// Digester is an interface used for generating digest values.
+type Digester interface {
+	io.Writer
+	// String() returns the digest value for the bytes written to the digester.
+	String() string
+}
+
+// alg is a built-in Alg
+type alg string
+
+func (a alg) ID() string { return string(a) }
+func (a alg) Digester() Digester {
+	if fn := builtInDigesters[a]; fn != nil {
+		return fn()
+	}
+	return nil
+}
+
+// hashDigester implements Digester using a hash.Hash
+type hashDigester struct {
+	hash.Hash
+}
+
+func (h hashDigester) String() string { return hex.EncodeToString(h.Sum(nil)) }
+
+func mustBlake2bNew512() hash.Hash {
+	h, err := blake2b.New512(nil)
+	if err != nil {
+		panic("creating new blake2b hash")
+	}
+	return h
+}

--- a/digest/algorithm.go
+++ b/digest/algorithm.go
@@ -7,16 +7,27 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"hash"
+	"strconv"
 
 	"golang.org/x/crypto/blake2b"
 )
 
 const (
+	// standard algorithms
+
 	SHA512  = alg(`sha512`)      // built-in Alg for sha512
 	SHA256  = alg(`sha256`)      // built-in Alg for sha256
 	SHA1    = alg(`sha1`)        // built-in Alg for sha1
 	MD5     = alg(`md5`)         // built-in Alg for md5
 	BLAKE2B = alg(`blake2b-512`) // built-in Alg for blake2b-512
+
+	// extended algorithms
+
+	BLAKE2B_160 = alg("blake2b-160")
+	BLAKE2B_256 = alg("blake2b-256")
+	BLAKE2B_384 = alg("blake2b-384")
+	SHA512_256  = alg("sha512/256")
+	SIZE        = alg("size")
 )
 
 // Algorithm is implemented by digest algorithms
@@ -33,7 +44,13 @@ var builtInDigesters = map[alg]func() Digester{
 	SHA256:  func() Digester { return &hashDigester{Hash: sha256.New()} },
 	SHA1:    func() Digester { return &hashDigester{Hash: sha1.New()} },
 	MD5:     func() Digester { return &hashDigester{Hash: md5.New()} },
-	BLAKE2B: func() Digester { return &hashDigester{Hash: mustBlake2bNew512()} },
+	BLAKE2B: func() Digester { return &hashDigester{Hash: mustNewBlake2B(64)} },
+
+	BLAKE2B_160: func() Digester { return &hashDigester{Hash: mustNewBlake2B(20)} },
+	BLAKE2B_256: func() Digester { return &hashDigester{Hash: mustNewBlake2B(32)} },
+	BLAKE2B_384: func() Digester { return &hashDigester{Hash: mustNewBlake2B(48)} },
+	SHA512_256:  func() Digester { return &hashDigester{Hash: sha512.New512_256()} },
+	SIZE:        func() Digester { return &sizeDigester{} },
 }
 
 // alg is a built-in Alg
@@ -54,8 +71,23 @@ func (h hashDigester) String() string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func mustBlake2bNew512() hash.Hash {
-	h, err := blake2b.New512(nil)
+// sizeDigester implements a Digester that counts bytes
+type sizeDigester struct {
+	size int64
+}
+
+func (d *sizeDigester) Write(b []byte) (int, error) {
+	l := len(b)
+	d.size += int64(l)
+	return l, nil
+}
+
+func (d *sizeDigester) String() string {
+	return strconv.FormatInt(d.size, 10)
+}
+
+func mustNewBlake2B(size int) hash.Hash {
+	h, err := blake2b.New(size, nil)
 	if err != nil {
 		panic("creating new blake2b hash")
 	}

--- a/digest/digester.go
+++ b/digest/digester.go
@@ -13,12 +13,6 @@ type Digester interface {
 	String() string
 }
 
-// NewDigester is a convenience function that returns a new
-// Digester for a built-in Alg with the given id.
-func NewDigester(id string) (Digester, error) {
-	return defaultRegister.NewDigester(id)
-}
-
 // MultiDigester is used to generate digests for multiple algorithms at the same
 // time.
 type MultiDigester struct {
@@ -29,9 +23,6 @@ type MultiDigester struct {
 // NewMultiDigester constructs a MultiDigester for one or more built-in digest
 // algorithms.
 func NewMultiDigester(algs ...Algorithm) *MultiDigester {
-	if len(algs) < 1 {
-		return &MultiDigester{Writer: io.Discard}
-	}
 	writers := make([]io.Writer, 0, len(algs))
 	digesters := make(map[string]Digester, len(algs))
 	for _, alg := range algs {

--- a/digest/digester.go
+++ b/digest/digester.go
@@ -1,0 +1,134 @@
+package digest
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Digester is an interface used for generating values.
+type Digester interface {
+	io.Writer
+	// String() returns the value for the bytes written to the r.
+	String() string
+}
+
+// NewDigester is a convenience function that returns a new
+// for a built-in Alg with the given id.
+func NewDigester(id string) (Digester, error) {
+	return builtinRegister.NewDigester(id)
+}
+
+// MultiDigester is used to generate  for multiple algorithms at
+// the same time.
+type MultiDigester struct {
+	io.Writer
+	digesters map[string]Digester
+}
+
+// NewMultiDigester constructs a MultiDigester for one or more built-in digest
+// algorithms.
+func NewMultiDigester(algs ...string) *MultiDigester {
+	writers := make([]io.Writer, 0, len(algs))
+	rs := make(map[string]Digester, len(algs))
+	for _, algID := range algs {
+		r, _ := NewDigester(algID)
+		if r == nil {
+			continue
+		}
+		rs[algID] = r
+		writers = append(writers, r)
+	}
+	if len(writers) == 0 {
+		return &MultiDigester{Writer: io.Discard}
+	}
+	return &MultiDigester{
+		Writer:    io.MultiWriter(writers...),
+		digesters: rs,
+	}
+}
+
+func (md MultiDigester) Sum(alg string) string {
+	if dig := md.digesters[alg]; dig != nil {
+		return dig.String()
+	}
+	return ""
+}
+
+// Sums returns a Set with all values for the MultiDigester
+func (md MultiDigester) Sums() Set {
+	set := make(Set, len(md.digesters))
+	for alg, r := range md.digesters {
+		set[alg] = r.String()
+	}
+	return set
+}
+
+// Set is a map of alg id to digest values
+type Set map[string]string
+
+func (s Set) Add(s2 Set) error {
+	for alg, newDigest := range s2 {
+		currDigest := s[alg]
+		if currDigest == "" {
+			s[alg] = newDigest
+			continue
+		}
+		if strings.EqualFold(currDigest, newDigest) {
+			continue
+		}
+		// conflict
+		return &DigestError{
+			Alg:      alg,
+			Got:      newDigest,
+			Expected: currDigest,
+		}
+	}
+	return nil
+}
+
+// ConflictsWith returns keys in s with values that do not match the
+// corresponding key in other. Values in each set are compared using
+// strings.EqualFold().
+func (s Set) ConflictsWith(other Set) []string {
+	var keys []string
+	for alg, sv := range s {
+		if ov, ok := other[alg]; ok && !strings.EqualFold(sv, ov) {
+			keys = append(keys, alg)
+		}
+	}
+	return keys
+}
+
+// Validate  reader and return an error if the resulting for any
+// algorithm in s doesn't match the value in s.
+func (s Set) Validate(reader io.Reader) error {
+	algs := make([]string, 0, len(s))
+	for alg := range s {
+		algs = append(algs, alg)
+	}
+	r := NewMultiDigester(algs...)
+	if _, err := io.Copy(r, reader); err != nil {
+		return err
+	}
+	result := r.Sums()
+	for _, alg := range result.ConflictsWith(s) {
+		return &DigestError{Alg: alg, Expected: s[alg], Got: result[alg]}
+	}
+	return nil
+}
+
+// DigestError is returned when content's conflicts with an expected value
+type DigestError struct {
+	Path     string // Content path
+	Alg      string // Digest algorithm
+	Got      string // Calculated digest
+	Expected string // Expected digest
+}
+
+func (e DigestError) Error() string {
+	if e.Path == "" {
+		return fmt.Sprintf("unexpected %s value: %q, expected=%q", e.Alg, e.Got, e.Expected)
+	}
+	return fmt.Sprintf("unexpected %s for %q: %q, expected=%q", e.Alg, e.Path, e.Got, e.Expected)
+}

--- a/digest/digester.go
+++ b/digest/digester.go
@@ -16,7 +16,7 @@ type Digester interface {
 // NewDigester is a convenience function that returns a new
 // Digester for a built-in Alg with the given id.
 func NewDigester(id string) (Digester, error) {
-	return builtinRegister.NewDigester(id)
+	return defaultRegister.NewDigester(id)
 }
 
 // MultiDigester is used to generate digests for multiple algorithms at the same
@@ -29,7 +29,7 @@ type MultiDigester struct {
 // NewMultiDigester constructs a MultiDigester for one or more built-in digest
 // algorithms.
 func NewMultiDigester(algs ...string) (*MultiDigester, error) {
-	return builtinRegister.NewMultiDigester(algs...)
+	return defaultRegister.NewMultiDigester(algs...)
 }
 
 func (md MultiDigester) Sum(alg string) string {

--- a/digest/digester.go
+++ b/digest/digester.go
@@ -64,6 +64,17 @@ func (md MultiDigester) Sums() Set {
 // Set is a map of alg id to digest values
 type Set map[string]string
 
+func (s Set) Algorithms() []string {
+	if len(s) == 0 {
+		return nil
+	}
+	algs := make([]string, 0, len(s))
+	for alg := range s {
+		algs = append(algs, alg)
+	}
+	return algs
+}
+
 func (s Set) Add(s2 Set) error {
 	for alg, newDigest := range s2 {
 		currDigest := s[alg]
@@ -95,27 +106,6 @@ func (s Set) ConflictsWith(other Set) []string {
 		}
 	}
 	return keys
-}
-
-// Validate  reader and return an error if the resulting for any
-// algorithm in s doesn't match the value in s.
-func (s Set) Validate(reader io.Reader) error {
-	algs := make([]string, 0, len(s))
-	for alg := range s {
-		algs = append(algs, alg)
-	}
-	r, err := defaultRegister.NewMultiDigester(algs...)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(r, reader); err != nil {
-		return err
-	}
-	result := r.Sums()
-	for _, alg := range result.ConflictsWith(s) {
-		return &DigestError{Alg: alg, Expected: s[alg], Got: result[alg]}
-	}
-	return nil
 }
 
 // DigestError is returned when content's conflicts with an expected value

--- a/digest/digester_test.go
+++ b/digest/digester_test.go
@@ -23,11 +23,7 @@ func TestDigester(t *testing.T) {
 		t.Helper()
 		data := []byte("content")
 		algRegistry := digest.DefaultRegistry()
-		dig, err := algRegistry.NewMultiDigester(algs...)
-		if err != nil {
-			t.Fatal(err)
-		}
-		// readfrom
+		dig := algRegistry.NewMultiDigester(algs...)
 		if _, err := io.Copy(dig, bytes.NewReader(data)); err != nil {
 			t.Fatal(err)
 		}
@@ -51,7 +47,7 @@ func TestDigester(t *testing.T) {
 		}
 		// add invalid entry
 		result[digest.SHA1.ID()] = "invalid"
-		err = algRegistry.Validate(bytes.NewReader(data), result)
+		err := algRegistry.Validate(bytes.NewReader(data), result)
 		if err == nil {
 			t.Error("Validate() didn't return an error for an invalid DigestSet")
 		}
@@ -67,7 +63,7 @@ func TestDigester(t *testing.T) {
 		}
 	}
 	t.Run("no algs", func(t *testing.T) {
-		d := digest.NewMultiDigester()
+		d := digest.DefaultRegistry().NewMultiDigester()
 		_, err := d.Write([]byte("test"))
 		be.NilErr(t, err)
 		be.Zero(t, len(d.Sums()))
@@ -94,7 +90,7 @@ func testAlg(algID string, val []byte) (string, error) {
 	case digest.BLAKE2B.ID():
 		h, _ = blake2b.New512(nil)
 	}
-	d, err := digest.NewDigester(algID)
+	d, err := digest.DefaultRegistry().NewDigester(algID)
 	if err != nil {
 		return "", err
 	}

--- a/digest/digester_test.go
+++ b/digest/digester_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/carlmjohnson/be"
 	"github.com/srerickson/ocfl-go/digest"
 	"golang.org/x/crypto/blake2b"
 )
@@ -21,7 +22,10 @@ func TestDigester(t *testing.T) {
 	testDigester := func(t *testing.T, algs []string) {
 		data := []byte("content")
 		t.Helper()
-		dig := digest.NewMultiDigester(algs...)
+		dig, err := digest.NewMultiDigester(algs...)
+		if err != nil {
+			t.Fatal(err)
+		}
 		// readfrom
 		if _, err := io.Copy(dig, bytes.NewReader(data)); err != nil {
 			t.Fatal(err)
@@ -46,7 +50,7 @@ func TestDigester(t *testing.T) {
 		}
 		// add invalid entry
 		result[digest.SHA1.ID()] = "invalid"
-		err := result.Validate(bytes.NewReader(data))
+		err = result.Validate(bytes.NewReader(data))
 		if err == nil {
 			t.Error("Validate() didn't return an error for an invalid DigestSet")
 		}
@@ -61,8 +65,9 @@ func TestDigester(t *testing.T) {
 			t.Error("Validate() returned an error with wrong Expected value")
 		}
 	}
-	t.Run("nil algs", func(t *testing.T) {
-		testDigester(t, nil)
+	t.Run("no algs", func(t *testing.T) {
+		_, err := digest.NewMultiDigester()
+		be.True(t, err != nil)
 	})
 	t.Run("1 alg", func(t *testing.T) {
 		testDigester(t, []string{digest.MD5.ID()})

--- a/digest/digester_test.go
+++ b/digest/digester_test.go
@@ -20,9 +20,10 @@ import (
 
 func TestDigester(t *testing.T) {
 	testDigester := func(t *testing.T, algs []string) {
-		data := []byte("content")
 		t.Helper()
-		dig, err := digest.DefaultRegister().NewMultiDigester(algs...)
+		data := []byte("content")
+		algRegistry := digest.DefaultRegistry()
+		dig, err := algRegistry.NewMultiDigester(algs...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -45,12 +46,12 @@ func TestDigester(t *testing.T) {
 				t.Errorf("ReadFrom() has unexpected result for %s: got=%q, expect=%q", alg, dig.Sum(alg), expect[alg])
 			}
 		}
-		if err := result.Validate(bytes.NewReader(data)); err != nil {
+		if err := algRegistry.Validate(bytes.NewReader(data), result); err != nil {
 			t.Error("Validate() unexpected error:", err)
 		}
 		// add invalid entry
 		result[digest.SHA1.ID()] = "invalid"
-		err = result.Validate(bytes.NewReader(data))
+		err = algRegistry.Validate(bytes.NewReader(data), result)
 		if err == nil {
 			t.Error("Validate() didn't return an error for an invalid DigestSet")
 		}

--- a/digest/digester_test.go
+++ b/digest/digester_test.go
@@ -22,7 +22,7 @@ func TestDigester(t *testing.T) {
 	testDigester := func(t *testing.T, algs []string) {
 		data := []byte("content")
 		t.Helper()
-		dig, err := digest.NewMultiDigester(algs...)
+		dig, err := digest.DefaultRegister().NewMultiDigester(algs...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,8 +66,10 @@ func TestDigester(t *testing.T) {
 		}
 	}
 	t.Run("no algs", func(t *testing.T) {
-		_, err := digest.NewMultiDigester()
-		be.True(t, err != nil)
+		d := digest.NewMultiDigester()
+		_, err := d.Write([]byte("test"))
+		be.NilErr(t, err)
+		be.Zero(t, len(d.Sums()))
 	})
 	t.Run("1 alg", func(t *testing.T) {
 		testDigester(t, []string{digest.MD5.ID()})

--- a/digest/digester_test.go
+++ b/digest/digester_test.go
@@ -42,12 +42,12 @@ func TestDigester(t *testing.T) {
 				t.Errorf("ReadFrom() has unexpected result for %s: got=%q, expect=%q", alg, dig.Sum(alg), expect[alg])
 			}
 		}
-		if err := algRegistry.Validate(bytes.NewReader(data), result); err != nil {
+		if err := result.Validate(bytes.NewReader(data), algRegistry); err != nil {
 			t.Error("Validate() unexpected error:", err)
 		}
 		// add invalid entry
 		result[digest.SHA1.ID()] = "invalid"
-		err := algRegistry.Validate(bytes.NewReader(data), result)
+		err := result.Validate(bytes.NewReader(data), algRegistry)
 		if err == nil {
 			t.Error("Validate() didn't return an error for an invalid DigestSet")
 		}

--- a/digest/digester_test.go
+++ b/digest/digester_test.go
@@ -1,0 +1,101 @@
+package digest_test
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"testing"
+
+	"github.com/srerickson/ocfl-go/digest"
+	"golang.org/x/crypto/blake2b"
+)
+
+func TestDigester(t *testing.T) {
+	testDigester := func(t *testing.T, algs []string) {
+		data := []byte("content")
+		t.Helper()
+		dig := digest.NewMultiDigester(algs...)
+		// readfrom
+		if _, err := io.Copy(dig, bytes.NewReader(data)); err != nil {
+			t.Fatal(err)
+		}
+		result := dig.Sums()
+		if l := len(result); l != len(algs) {
+			t.Fatalf("Sums() returned wrong number of entries: got=%d, expect=%d", l, len(algs))
+		}
+		expect := digest.Set{}
+		for alg := range result {
+			var err error
+			expect[alg], err = testAlg(alg, data)
+			if err != nil {
+				t.Error(err)
+			}
+			if expect[alg] != result[alg] {
+				t.Errorf("ReadFrom() has unexpected result for %s: got=%q, expect=%q", alg, dig.Sum(alg), expect[alg])
+			}
+		}
+		if err := result.Validate(bytes.NewReader(data)); err != nil {
+			t.Error("Validate() unexpected error:", err)
+		}
+		// add invalid entry
+		result[digest.SHA1.ID()] = "invalid"
+		err := result.Validate(bytes.NewReader(data))
+		if err == nil {
+			t.Error("Validate() didn't return an error for an invalid DigestSet")
+		}
+		var digestErr *digest.DigestError
+		if !errors.As(err, &digestErr) {
+			t.Error("Validate() didn't return a DigestErr as expected")
+		}
+		if digestErr.Alg != digest.SHA1.ID() {
+			t.Error("Validate() returned an error with the wrong Alg value")
+		}
+		if digestErr.Expected != result[digest.SHA1.ID()] {
+			t.Error("Validate() returned an error with wrong Expected value")
+		}
+	}
+	t.Run("nil algs", func(t *testing.T) {
+		testDigester(t, nil)
+	})
+	t.Run("1 alg", func(t *testing.T) {
+		testDigester(t, []string{digest.MD5.ID()})
+	})
+	t.Run("2 algs", func(t *testing.T) {
+		testDigester(t, []string{digest.MD5.ID(), digest.BLAKE2B.ID()})
+	})
+}
+
+func testAlg(algID string, val []byte) (string, error) {
+	var h hash.Hash
+	switch algID {
+	case digest.SHA512.ID():
+		h = sha512.New()
+	case digest.SHA256.ID():
+		h = sha256.New()
+	case digest.SHA1.ID():
+		h = sha1.New()
+	case digest.MD5.ID():
+		h = md5.New()
+	case digest.BLAKE2B.ID():
+		h, _ = blake2b.New512(nil)
+	}
+	d, err := digest.NewDigester(algID)
+	if err != nil {
+		return "", err
+	}
+	d.Write(val)
+	h.Write(val)
+	exp := hex.EncodeToString(h.Sum(nil))
+	got := d.String()
+	if exp != got {
+		return exp, fmt.Errorf("%s value: got=%q, expected=%q", algID, got, exp)
+	}
+	return exp, nil
+}

--- a/digest/register.go
+++ b/digest/register.go
@@ -1,0 +1,65 @@
+package digest
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrUnknown = errors.New("unrecognized digest algorithm")
+	Defaults   = DefaultRegister()
+)
+
+// Register is an immutable container of Algs.
+type Register struct {
+	algs map[string]Alg
+}
+
+// NewRegister returns a Register for the given extension algs
+func NewRegister(algs ...Alg) Register {
+	newR := Register{
+		algs: make(map[string]Alg, len(algs)),
+	}
+	for _, alg := range algs {
+		newR.algs[alg.ID()] = alg
+	}
+	return newR
+}
+
+// New returns the Alg for the given id or ErrUnknown if the algorithm is not
+// present in the register.
+func (r Register) New(id string) (Alg, error) {
+	alg, ok := r.algs[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknown, id)
+	}
+	return alg, nil
+}
+
+// Append returns a new Register that includes algs from r plus additional algs.
+// If the added algs have the same id as those in r, the new register will use
+// new algs.
+func (r Register) Append(algs ...Alg) Register {
+	newR := Register{
+		algs: make(map[string]Alg, len(r.algs)+len(algs)),
+	}
+	for _, alg := range r.algs {
+		newR.algs[alg.ID()] = alg
+	}
+	for _, alg := range algs {
+		newR.algs[alg.ID()] = alg
+	}
+	return newR
+}
+
+// Names returns names of all Alg IDs in r.
+func (r Register) Names() []string {
+	names := make([]string, 0, len(r.algs))
+	for name := range r.algs {
+		names = append(names, name)
+	}
+	return names
+}
+
+// DefaultRegister returns a new Register with default Alg constructors.
+func DefaultRegister() Register { return NewRegister(builtin...) }

--- a/digest/register.go
+++ b/digest/register.go
@@ -10,13 +10,13 @@ var (
 	// ErrUnknown: a digest algorithm was not recognize
 	ErrUnknown = errors.New("unrecognized digest algorithm")
 	// ErrMissing: missing an expected digest algorithm
-	ErrMissing = errors.New("missing a required digest algorithm")
+	ErrMissing = errors.New("missing an expected digest algorithm")
 
 	// built-in Alg register
 	builtinRegister = NewRegister(SHA512, SHA256, SHA1, MD5, BLAKE2B)
 )
 
-// Register is an immutable container of Algs.
+// Register is an immutable collection of available Algs.
 type Register struct {
 	algs map[string]Alg
 }

--- a/digest/registry.go
+++ b/digest/registry.go
@@ -42,6 +42,16 @@ func (r Registry) Get(id string) (Algorithm, error) {
 	return alg, nil
 }
 
+// MustGet is like Get except it panics if the registry does not include
+// the an algorithm with the given id.
+func (r Registry) MustGet(id string) Algorithm {
+	alg, err := r.Get(id)
+	if err != nil {
+		panic(err)
+	}
+	return alg
+}
+
 // NewDigester returns a digester for the given id, which must an Alg registered
 // in r.
 func (r Registry) NewDigester(id string) (Digester, error) {

--- a/digest_test.go
+++ b/digest_test.go
@@ -38,7 +38,7 @@ func TestDigestFS(t *testing.T) {
 			add("hello.csv", []string{"bad"})
 		}
 		for digests, err := range ocfl.Digest(ctx, fsys, setup) {
-			be.NilErr(t, err)
+			be.True(t, err != nil)
 			be.Zero(t, len(digests.Digests))
 		}
 	})
@@ -70,7 +70,7 @@ func TestDigestFS(t *testing.T) {
 			add("hello.csv", nil)
 		}
 		for r, err := range ocfl.Digest(ctx, fsys, setup) {
-			be.NilErr(t, err)
+			be.True(t, err != nil)
 			be.Zero(t, len(r.Digests))
 		}
 	})

--- a/digest_test.go
+++ b/digest_test.go
@@ -2,11 +2,8 @@ package ocfl_test
 
 import (
 	"context"
-	"errors"
-	"io/fs"
 	"path/filepath"
 	"testing"
-	"testing/fstest"
 
 	"github.com/carlmjohnson/be"
 	"github.com/srerickson/ocfl-go"
@@ -63,55 +60,6 @@ func TestDigestFS(t *testing.T) {
 		for r, err := range ocfl.Digest(ctx, fsys, setup) {
 			be.NilErr(t, err)
 			be.Zero(t, len(r.Digests))
-		}
-	})
-}
-
-func TestPathDigests(t *testing.T) {
-	ctx := context.Background()
-	fsys := fstest.MapFS{
-		"data/sample.txt":        &fstest.MapFile{Data: []byte("some content1")},
-		"data/sample2.txt":       &fstest.MapFile{Data: []byte("some content2")},
-		"data/sample3.txt":       &fstest.MapFile{Data: []byte("some content3")},
-		"data/sample4.txt":       &fstest.MapFile{Data: []byte("some content4")},
-		"data/sample5.txt":       &fstest.MapFile{Data: []byte("some content5")},
-		"data/subdir/sample.txt": &fstest.MapFile{Data: []byte("some content6")},
-	}
-	t.Run("example", func(t *testing.T) {
-		jobs := func(yield func(string, []digest.Algorithm) bool) {
-			for name := range fsys {
-				yield(name, []digest.Algorithm{digest.SHA256, digest.MD5})
-			}
-		}
-		for pd, err := range ocfl.Digest(ctx, ocfl.NewFS(fsys), jobs) {
-			be.NilErr(t, err)
-			valid, err := pd.Validate(ctx, ocfl.NewFS(fsys), ".")
-			be.True(t, valid)
-			be.NilErr(t, err)
-		}
-		for pd, err := range ocfl.Digest(ctx, ocfl.NewFS(fsys), jobs) {
-			be.NilErr(t, err)
-			pd.Digests["sha1"] = "baddigest"
-			valid, err := pd.Validate(ctx, ocfl.NewFS(fsys), ".")
-			be.False(t, valid)
-			var digestErr *digest.DigestError
-			be.True(t, errors.As(err, &digestErr))
-		}
-		for pd, err := range ocfl.Digest(ctx, ocfl.NewFS(fsys), jobs) {
-			be.NilErr(t, err)
-			// fsys with different content
-			fsys := fstest.MapFS{pd.Path: &fstest.MapFile{Data: []byte("changed!")}}
-			valid, err := pd.Validate(ctx, ocfl.NewFS(fsys), ".")
-			be.False(t, valid)
-			var digestErr *digest.DigestError
-			be.True(t, errors.As(err, &digestErr))
-		}
-		for pd, err := range ocfl.Digest(ctx, ocfl.NewFS(fsys), jobs) {
-			be.NilErr(t, err)
-			fsys := fstest.MapFS{} // file is missing
-			valid, err := pd.Validate(ctx, ocfl.NewFS(fsys), ".")
-			be.False(t, valid)
-			be.True(t, errors.Is(err, fs.ErrNotExist))
 		}
 	})
 }

--- a/examples/commit/main.go
+++ b/examples/commit/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/srerickson/ocfl-go"
 	"github.com/srerickson/ocfl-go/backend/local"
+	"github.com/srerickson/ocfl-go/digest"
 	"github.com/srerickson/ocfl-go/ocflv1"
 )
 
@@ -16,7 +17,7 @@ var (
 	objPath string // path to object
 	srcDir  string // path to content directory
 	msg     string // message for new version
-	alg     string // digest algorith (sha512 or sha256)
+	algID   string // digest algorith (sha512 or sha256)
 	newID   string // ID for new object
 	user    ocfl.User
 
@@ -31,7 +32,7 @@ func main() {
 	flag.StringVar(&msg, "msg", "", "message field for new version")
 	flag.StringVar(&user.Name, "name", "", "name field for new version")
 	flag.StringVar(&user.Address, "email", "", "email field for new version")
-	flag.StringVar(&alg, "alg", "sha512", "digest algorith for new version")
+	flag.StringVar(&algID, "alg", "sha512", "digest algorith for new version")
 	flag.StringVar(&newID, "id", "", "object ID (required for new objects)")
 	flag.Parse()
 
@@ -59,6 +60,10 @@ func main() {
 	}
 	if !obj.Exists() && newID == "" {
 		err := errors.New("object needs to be created, but 'id' flag is missing")
+		quit(err)
+	}
+	alg, err := digest.DefaultRegister().Get(algID)
+	if err != nil {
 		quit(err)
 	}
 	stage, err := ocfl.StageDir(ctx, ocfl.DirFS(srcDir), ".", alg)

--- a/examples/commit/main.go
+++ b/examples/commit/main.go
@@ -62,7 +62,7 @@ func main() {
 		err := errors.New("object needs to be created, but 'id' flag is missing")
 		quit(err)
 	}
-	alg, err := digest.DefaultRegister().Get(algID)
+	alg, err := digest.DefaultRegistry().Get(algID)
 	if err != nil {
 		quit(err)
 	}

--- a/extension/0001_digest_algorithms.go
+++ b/extension/0001_digest_algorithms.go
@@ -6,12 +6,12 @@ import (
 	"github.com/srerickson/ocfl-go/digest"
 )
 
-const ext0009name = "0009-digest-algorithms"
+const ext0001name = "0009-digest-algorithms"
 
-//go:embed docs/0009-digest-algorithms.md
-var ext0009doc []byte
+//go:embed docs/0001-digest-algorithms.md
+var ext0001doc []byte
 
-func Ext0009() AlgorithmRegistry {
+func Ext0001() AlgorithmRegistry {
 	ext := algRegistry{
 		Base: Base{ExtensionName: ext0009name},
 	}
@@ -20,7 +20,6 @@ func Ext0009() AlgorithmRegistry {
 		&alg{id: "blake2b-256", ext: ext},
 		&alg{id: "blake2b-384", ext: ext},
 		&alg{id: "sha512/256", ext: ext},
-		&alg{id: "size", ext: ext},
 	)
 	return ext
 }

--- a/extension/0001_digest_algorithms.go
+++ b/extension/0001_digest_algorithms.go
@@ -10,7 +10,7 @@ func Ext0001() Extension {
 	ext := &algRegistry{
 		Base: Base{ExtensionName: ext0001},
 	}
-	ext.algs = digest.NewRegistry(
+	ext.algs = digest.NewAlgorithmRegistry(
 		&alg{Algorithm: digest.BLAKE2B_160, ext: ext},
 		&alg{Algorithm: digest.BLAKE2B_256, ext: ext},
 		&alg{Algorithm: digest.BLAKE2B_384, ext: ext},

--- a/extension/0001_digest_algorithms.go
+++ b/extension/0001_digest_algorithms.go
@@ -1,19 +1,14 @@
 package extension
 
 import (
-	_ "embed"
-
 	"github.com/srerickson/ocfl-go/digest"
 )
 
-const ext0001name = "0009-digest-algorithms"
+const ext0001 = "0009-digest-algorithms"
 
-//go:embed docs/0001-digest-algorithms.md
-var ext0001doc []byte
-
-func Ext0001() AlgorithmRegistry {
+func Ext0001() Extension {
 	ext := algRegistry{
-		Base: Base{ExtensionName: ext0009name},
+		Base: Base{ExtensionName: ext0009},
 	}
 	ext.algs = digest.NewRegistry(
 		&alg{id: "blake2b-160", ext: ext},

--- a/extension/0001_digest_algorithms.go
+++ b/extension/0001_digest_algorithms.go
@@ -11,10 +11,10 @@ func Ext0001() Extension {
 		Base: Base{ExtensionName: ext0001},
 	}
 	ext.algs = digest.NewRegistry(
-		&alg{id: "blake2b-160", ext: ext},
-		&alg{id: "blake2b-256", ext: ext},
-		&alg{id: "blake2b-384", ext: ext},
-		&alg{id: "sha512/256", ext: ext},
+		&alg{Algorithm: digest.BLAKE2B_160, ext: ext},
+		&alg{Algorithm: digest.BLAKE2B_256, ext: ext},
+		&alg{Algorithm: digest.BLAKE2B_384, ext: ext},
+		&alg{Algorithm: digest.SHA512_256, ext: ext},
 	)
 	return ext
 }

--- a/extension/0001_digest_algorithms.go
+++ b/extension/0001_digest_algorithms.go
@@ -4,11 +4,11 @@ import (
 	"github.com/srerickson/ocfl-go/digest"
 )
 
-const ext0001 = "0009-digest-algorithms"
+const ext0001 = "0001-digest-algorithms"
 
 func Ext0001() Extension {
-	ext := algRegistry{
-		Base: Base{ExtensionName: ext0009},
+	ext := &algRegistry{
+		Base: Base{ExtensionName: ext0001},
 	}
 	ext.algs = digest.NewRegistry(
 		&alg{id: "blake2b-160", ext: ext},

--- a/extension/0001_digest_algorithms_test.go
+++ b/extension/0001_digest_algorithms_test.go
@@ -1,0 +1,29 @@
+package extension_test
+
+import (
+	"testing"
+
+	"github.com/carlmjohnson/be"
+	"github.com/srerickson/ocfl-go/extension"
+)
+
+func TestExt0001DigestAlgorithms(t *testing.T) {
+	t.Run("digest values", func(t *testing.T) {
+		algExt, ok := extension.Ext0001().(extension.AlgorithmRegistry)
+		be.True(t, ok)
+		hashData := []byte("hello world")
+		table := map[string]string{
+			"blake2b-160": "70e8ece5e293e1bda064deef6b080edde357010f",
+			"blake2b-256": "256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610",
+			"blake2b-384": "8c653f8c9c9aa2177fb6f8cf5bb914828faa032d7b486c8150663d3f6524b086784f8e62693171ac51fc80b7d2cbb12b",
+			"sha512/256":  "0ac561fac838104e3f2e4ad107b4bee3e938bf15f2b15f009ccccd61a913f017",
+		}
+		for id, digest := range table {
+			t.Run(id, func(t *testing.T) {
+				digester := algExt.Algorithms().MustGet(id).Digester()
+				digester.Write(hashData)
+				be.Equal(t, digest, digester.String())
+			})
+		}
+	})
+}

--- a/extension/0002_layout_flatdirect.go
+++ b/extension/0002_layout_flatdirect.go
@@ -1,21 +1,6 @@
 package extension
 
-import (
-	_ "embed"
-)
-
 const ext0002 = "0002-flat-direct-storage-layout"
-
-//go:embed docs/0002-flat-direct-storage-layout.md
-var ext0002doc []byte
-
-// LayoutFlatDirect implements 0002-flat-direct-storage-layout
-type LayoutFlatDirect struct {
-	Base
-}
-
-var _ (Layout) = (*LayoutFlatDirect)(nil)
-var _ (Extension) = (*LayoutFlatDirect)(nil)
 
 // Ext0002 returns new instance of 0002-flat-direct-storage-layout with default values
 func Ext0002() Extension {
@@ -24,6 +9,10 @@ func Ext0002() Extension {
 	}
 }
 
-func (l LayoutFlatDirect) Documentation() []byte             { return ext0002doc }
+// LayoutFlatDirect implements 0002-flat-direct-storage-layout
+type LayoutFlatDirect struct {
+	Base
+}
+
 func (l LayoutFlatDirect) Resolve(id string) (string, error) { return id, nil }
 func (l LayoutFlatDirect) Valid() error                      { return nil }

--- a/extension/0002_layout_flatdirect.go
+++ b/extension/0002_layout_flatdirect.go
@@ -2,7 +2,6 @@ package extension
 
 import (
 	_ "embed"
-	"encoding/json"
 )
 
 const ext0002 = "0002-flat-direct-storage-layout"
@@ -11,19 +10,20 @@ const ext0002 = "0002-flat-direct-storage-layout"
 var ext0002doc []byte
 
 // LayoutFlatDirect implements 0002-flat-direct-storage-layout
-type LayoutFlatDirect struct{}
+type LayoutFlatDirect struct {
+	Base
+}
 
 var _ (Layout) = (*LayoutFlatDirect)(nil)
 var _ (Extension) = (*LayoutFlatDirect)(nil)
 
 // Ext0002 returns new instance of 0002-flat-direct-storage-layout with default values
-func Ext0002() Extension { return &LayoutFlatDirect{} }
+func Ext0002() Extension {
+	return &LayoutFlatDirect{
+		Base: Base{ExtensionName: ext0002},
+	}
+}
 
-func (l LayoutFlatDirect) Name() string                      { return ext0002 }
 func (l LayoutFlatDirect) Documentation() []byte             { return ext0002doc }
 func (l LayoutFlatDirect) Resolve(id string) (string, error) { return id, nil }
 func (l LayoutFlatDirect) Valid() error                      { return nil }
-
-func (l LayoutFlatDirect) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]string{"extensionName": ext0002})
-}

--- a/extension/0002_layout_flatdirect_test.go
+++ b/extension/0002_layout_flatdirect_test.go
@@ -1,0 +1,6 @@
+package extension_test
+
+import "github.com/srerickson/ocfl-go/extension"
+
+var _ (extension.Layout) = (*extension.LayoutFlatDirect)(nil)
+var _ (extension.Extension) = (*extension.LayoutFlatDirect)(nil)

--- a/extension/0003_layout_hash_id_tuple.go
+++ b/extension/0003_layout_hash_id_tuple.go
@@ -44,7 +44,7 @@ func (l LayoutHashIDTuple) Name() string { return ext0003 }
 func (l LayoutHashIDTuple) Documentation() []byte { return ext0003doc }
 
 func (l LayoutHashIDTuple) Valid() error {
-	h := getAlg(l.DigestAlgorithm)
+	h := getHash(l.DigestAlgorithm)
 	if h == nil {
 		return fmt.Errorf("unknown digest algorithm: %q", l.DigestAlgorithm)
 	}
@@ -66,7 +66,7 @@ func (l LayoutHashIDTuple) Resolve(id string) (string, error) {
 	if err := l.Valid(); err != nil {
 		return "", err
 	}
-	h := getAlg(l.DigestAlgorithm)
+	h := getHash(l.DigestAlgorithm)
 	tupSize, tupNum := l.TupleSize, l.TupleNum
 	h.Write([]byte(id))
 	hID := hex.EncodeToString(h.Sum(nil))

--- a/extension/0003_layout_hash_id_tuple.go
+++ b/extension/0003_layout_hash_id_tuple.go
@@ -1,7 +1,6 @@
 package extension
 
 import (
-	_ "embed"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -16,9 +15,6 @@ const (
 	lowerhex        = "0123456789abcdef"
 )
 
-//go:embed docs/0003-hash-and-id-n-tuple-storage-layout.md
-var ext0003doc []byte
-
 // LayoutHashIDTuple implements 0003-hash-and-id-n-tuple-storage-layout
 type LayoutHashIDTuple struct {
 	Base
@@ -26,9 +22,6 @@ type LayoutHashIDTuple struct {
 	TupleSize       int    `json:"tupleSize"`
 	TupleNum        int    `json:"numberOfTuples"`
 }
-
-var _ (Layout) = (*LayoutHashIDTuple)(nil)
-var _ (Extension) = (*LayoutHashIDTuple)(nil)
 
 // Ext0003 returns a new instance of 0003-hash-and-id-n-tuple-storage-layout with default values
 func Ext0003() Extension {
@@ -39,8 +32,6 @@ func Ext0003() Extension {
 		TupleNum:        3,
 	}
 }
-
-func (l LayoutHashIDTuple) Documentation() []byte { return ext0003doc }
 
 func (l LayoutHashIDTuple) Valid() error {
 	h := getHash(l.DigestAlgorithm)

--- a/extension/0003_layout_hash_id_tuple.go
+++ b/extension/0003_layout_hash_id_tuple.go
@@ -3,7 +3,6 @@ package extension
 import (
 	_ "embed"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -22,6 +21,7 @@ var ext0003doc []byte
 
 // LayoutHashIDTuple implements 0003-hash-and-id-n-tuple-storage-layout
 type LayoutHashIDTuple struct {
+	Base
 	DigestAlgorithm string `json:"digestAlgorithm"`
 	TupleSize       int    `json:"tupleSize"`
 	TupleNum        int    `json:"numberOfTuples"`
@@ -33,13 +33,12 @@ var _ (Extension) = (*LayoutHashIDTuple)(nil)
 // Ext0003 returns a new instance of 0003-hash-and-id-n-tuple-storage-layout with default values
 func Ext0003() Extension {
 	return &LayoutHashIDTuple{
+		Base:            Base{ExtensionName: ext0003},
 		DigestAlgorithm: "sha256",
 		TupleSize:       3,
 		TupleNum:        3,
 	}
 }
-
-func (l LayoutHashIDTuple) Name() string { return ext0003 }
 
 func (l LayoutHashIDTuple) Documentation() []byte { return ext0003doc }
 
@@ -80,15 +79,6 @@ func (l LayoutHashIDTuple) Resolve(id string) (string, error) {
 	}
 	tuples[tupNum] = encID
 	return strings.Join(tuples, "/"), nil
-}
-
-func (l LayoutHashIDTuple) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]any{
-		extensionName:   ext0003,
-		digestAlgorithm: l.DigestAlgorithm,
-		tupleSize:       l.TupleSize,
-		numberOfTuples:  l.TupleNum,
-	})
 }
 
 func percentEncode(in string) string {

--- a/extension/0003_layout_hash_id_tuple_test.go
+++ b/extension/0003_layout_hash_id_tuple_test.go
@@ -3,26 +3,33 @@ package extension_test
 import (
 	"testing"
 
+	"github.com/carlmjohnson/be"
 	"github.com/srerickson/ocfl-go/extension"
 )
 
+var _ (extension.Layout) = (*extension.LayoutHashIDTuple)(nil)
+var _ (extension.Extension) = (*extension.LayoutHashIDTuple)(nil)
+
 func TestLayoutHashIDTuple(t *testing.T) {
-	{
+	t.Run("defualt values", func(t *testing.T) {
 		layout := extension.Ext0003().(*extension.LayoutHashIDTuple)
 		table := map[string]string{
 			`object-01`:        `3c0/ff4/240/object-01`,
 			`..hor/rib:le-$id`: `487/326/d8c/%2e%2ehor%2frib%3ale-%24id`,
 			`..Hor/rib:lè-$id`: `373/529/21a/%2e%2eHor%2frib%3al%c3%a8-%24id`,
 		}
+		be.Nonzero(t, layout.Doc())
+		be.Equal(t, "0003-hash-and-id-n-tuple-storage-layout", layout.Name())
 		for in, exp := range table {
 			testLayoutExt(t, layout, in, exp)
 		}
-	}
-	{
-		layout := extension.LayoutHashIDTuple{}
-		layout.DigestAlgorithm = "md5"
-		layout.TupleSize = 2
-		layout.TupleNum = 15
+	})
+	t.Run("custom values", func(t *testing.T) {
+		layout := extension.LayoutHashIDTuple{
+			DigestAlgorithm: "md5",
+			TupleSize:       2,
+			TupleNum:        15,
+		}
 		table := map[string]string{
 			"object-01":        "ff/75/53/44/92/48/5e/ab/b3/9f/86/35/67/28/88/object-01",
 			"..hor/rib:le-$id": "08/31/97/66/fb/6c/29/35/dd/17/5b/94/26/77/17/%2e%2ehor%2frib%3ale-%24id",
@@ -30,9 +37,8 @@ func TestLayoutHashIDTuple(t *testing.T) {
 		for in, exp := range table {
 			testLayoutExt(t, layout, in, exp)
 		}
-	}
-	{
-		// 4-tuple
+	})
+	t.Run("default: 4-tuple", func(t *testing.T) {
 		l := extension.Ext0003().(*extension.LayoutHashIDTuple)
 		l.TupleNum = 4
 		table := map[string]string{
@@ -41,6 +47,5 @@ func TestLayoutHashIDTuple(t *testing.T) {
 		for in, exp := range table {
 			testLayoutExt(t, l, in, exp)
 		}
-	}
-
+	})
 }

--- a/extension/0004_layout_hashtuple.go
+++ b/extension/0004_layout_hashtuple.go
@@ -43,7 +43,7 @@ func (l LayoutHashTuple) Name() string { return ext0004 }
 func (l LayoutHashTuple) Documentation() []byte { return ext0004doc }
 
 func (l LayoutHashTuple) Valid() error {
-	h := getAlg(l.DigestAlgorithm)
+	h := getHash(l.DigestAlgorithm)
 	if h == nil {
 		return fmt.Errorf("unknown digest algorithm: %q", l.DigestAlgorithm)
 	}
@@ -65,7 +65,7 @@ func (l LayoutHashTuple) Resolve(id string) (string, error) {
 	if err := l.Valid(); err != nil {
 		return "", err
 	}
-	h := getAlg(l.DigestAlgorithm)
+	h := getHash(l.DigestAlgorithm)
 	h.Write([]byte(id))
 	hID := hex.EncodeToString(h.Sum(nil))
 	tupSize, tupNum := l.TupleSize, l.TupleNum

--- a/extension/0004_layout_hashtuple.go
+++ b/extension/0004_layout_hashtuple.go
@@ -1,7 +1,6 @@
 package extension
 
 import (
-	_ "embed"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -13,9 +12,6 @@ const (
 	shortObjectRoot = "shortObjectRoot"
 )
 
-//go:embed docs/0004-hashed-n-tuple-storage-layout.md
-var ext0004doc []byte
-
 // LayoutHashTuple implements 0004-hashed-n-tuple-storage-layout
 type LayoutHashTuple struct {
 	Base
@@ -24,9 +20,6 @@ type LayoutHashTuple struct {
 	TupleNum        int    `json:"numberOfTuples"`
 	Short           bool   `json:"shortObjectRoot"`
 }
-
-var _ (Layout) = (*LayoutHashTuple)(nil)
-var _ (Extension) = (*LayoutHashTuple)(nil)
 
 // Ext0004 returns a new instance of 0004-hashed-n-tuple-storage-layout
 func Ext0004() Extension {
@@ -38,8 +31,6 @@ func Ext0004() Extension {
 		Short:           false,
 	}
 }
-
-func (l LayoutHashTuple) Documentation() []byte { return ext0004doc }
 
 func (l LayoutHashTuple) Valid() error {
 	h := getHash(l.DigestAlgorithm)

--- a/extension/0004_layout_hashtuple.go
+++ b/extension/0004_layout_hashtuple.go
@@ -3,7 +3,6 @@ package extension
 import (
 	_ "embed"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -19,6 +18,7 @@ var ext0004doc []byte
 
 // LayoutHashTuple implements 0004-hashed-n-tuple-storage-layout
 type LayoutHashTuple struct {
+	Base
 	DigestAlgorithm string `json:"digestAlgorithm"`
 	TupleSize       int    `json:"tupleSize"`
 	TupleNum        int    `json:"numberOfTuples"`
@@ -31,14 +31,13 @@ var _ (Extension) = (*LayoutHashTuple)(nil)
 // Ext0004 returns a new instance of 0004-hashed-n-tuple-storage-layout
 func Ext0004() Extension {
 	return &LayoutHashTuple{
+		Base:            Base{ExtensionName: ext0004},
 		DigestAlgorithm: `sha256`,
 		TupleSize:       3,
 		TupleNum:        3,
 		Short:           false,
 	}
 }
-
-func (l LayoutHashTuple) Name() string { return ext0004 }
 
 func (l LayoutHashTuple) Documentation() []byte { return ext0004doc }
 
@@ -79,14 +78,4 @@ func (l LayoutHashTuple) Resolve(id string) (string, error) {
 		tuples[tupNum] = hID
 	}
 	return strings.Join(tuples, "/"), nil
-}
-
-func (l LayoutHashTuple) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]any{
-		extensionName:   ext0004,
-		digestAlgorithm: l.DigestAlgorithm,
-		tupleSize:       l.TupleSize,
-		numberOfTuples:  l.TupleNum,
-		shortObjectRoot: l.Short,
-	})
 }

--- a/extension/0004_layout_hashtuple_test.go
+++ b/extension/0004_layout_hashtuple_test.go
@@ -1,0 +1,6 @@
+package extension_test
+
+import "github.com/srerickson/ocfl-go/extension"
+
+var _ (extension.Layout) = (*extension.LayoutHashTuple)(nil)
+var _ (extension.Extension) = (*extension.LayoutHashTuple)(nil)

--- a/extension/0006_layout_flat_omit_prefix.go
+++ b/extension/0006_layout_flat_omit_prefix.go
@@ -1,7 +1,6 @@
 package extension
 
 import (
-	_ "embed"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -13,17 +12,11 @@ const (
 	delimiter = "delimiter"
 )
 
-//go:embed docs/0006-flat-omit-prefix-storage-layout.md
-var ext0006doc []byte
-
 // LayoutFlatOmitPrefix implements 0006-flat-omit-prefix-storage-layout
 type LayoutFlatOmitPrefix struct {
 	Base
 	Delimiter string `json:"delimiter"`
 }
-
-var _ (Layout) = (*LayoutFlatOmitPrefix)(nil)
-var _ (Extension) = (*LayoutFlatOmitPrefix)(nil)
 
 // Ext0006 returns a new instance of 0006-flat-omit-prefix-storage-layout with default values
 func Ext0006() Extension {
@@ -32,8 +25,6 @@ func Ext0006() Extension {
 		Delimiter: ``,
 	}
 }
-
-func (l LayoutFlatOmitPrefix) Documentation() []byte { return ext0006doc }
 
 func (l LayoutFlatOmitPrefix) Valid() error {
 	if l.Delimiter == "" {

--- a/extension/0006_layout_flat_omit_prefix.go
+++ b/extension/0006_layout_flat_omit_prefix.go
@@ -2,7 +2,6 @@ package extension
 
 import (
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -19,6 +18,7 @@ var ext0006doc []byte
 
 // LayoutFlatOmitPrefix implements 0006-flat-omit-prefix-storage-layout
 type LayoutFlatOmitPrefix struct {
+	Base
 	Delimiter string `json:"delimiter"`
 }
 
@@ -27,10 +27,11 @@ var _ (Extension) = (*LayoutFlatOmitPrefix)(nil)
 
 // Ext0006 returns a new instance of 0006-flat-omit-prefix-storage-layout with default values
 func Ext0006() Extension {
-	return &LayoutFlatOmitPrefix{Delimiter: ``}
+	return &LayoutFlatOmitPrefix{
+		Base:      Base{ExtensionName: ext0006},
+		Delimiter: ``,
+	}
 }
-
-func (l LayoutFlatOmitPrefix) Name() string { return ext0006 }
 
 func (l LayoutFlatOmitPrefix) Documentation() []byte { return ext0006doc }
 
@@ -56,11 +57,4 @@ func (l LayoutFlatOmitPrefix) Resolve(id string) (string, error) {
 		return "", fmt.Errorf("object id %q is invalid for the layout", id)
 	}
 	return dir, nil
-}
-
-func (l LayoutFlatOmitPrefix) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]any{
-		extensionName: ext0006,
-		delimiter:     l.Delimiter,
-	})
 }

--- a/extension/0006_layout_flat_omit_prefix_test.go
+++ b/extension/0006_layout_flat_omit_prefix_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/srerickson/ocfl-go/extension"
 )
 
+var _ (extension.Layout) = (*extension.LayoutFlatOmitPrefix)(nil)
+var _ (extension.Extension) = (*extension.LayoutFlatOmitPrefix)(nil)
+
 func TestLayoutFlatOmitPrefix(t *testing.T) {
 	type test struct {
 		delim  string

--- a/extension/0007_layout_tuple_omit_prefix.go
+++ b/extension/0007_layout_tuple_omit_prefix.go
@@ -1,7 +1,6 @@
 package extension
 
 import (
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -16,9 +15,6 @@ const (
 	reverseObjectRoot = "reverseObjectRoot"
 )
 
-//go:embed docs/0007-n-tuple-omit-prefix-storage-layout.md
-var ext0007doc []byte
-
 // LayoutTupleOmitPrefix implements 0007-n-tuple-omit-prefix-storage-layout
 type LayoutTupleOmitPrefix struct {
 	Base
@@ -28,9 +24,6 @@ type LayoutTupleOmitPrefix struct {
 	Padding   string `json:"zeroPadding"`
 	Reverse   bool   `json:"reverseObjectRoot"`
 }
-
-var _ (Layout) = (*LayoutTupleOmitPrefix)(nil)
-var _ (Extension) = (*LayoutTupleOmitPrefix)(nil)
 
 // Ext0007 returns a new instance of 0007-n-tuple-omit-prefix-storage-layout with default values
 func Ext0007() Extension {
@@ -43,8 +36,6 @@ func Ext0007() Extension {
 		Reverse:   false,
 	}
 }
-
-func (l LayoutTupleOmitPrefix) Documentation() []byte { return ext0007doc }
 
 func (l LayoutTupleOmitPrefix) Valid() error {
 	if l.TupleSize < 1 {

--- a/extension/0007_layout_tuple_omit_prefix.go
+++ b/extension/0007_layout_tuple_omit_prefix.go
@@ -21,6 +21,7 @@ var ext0007doc []byte
 
 // LayoutTupleOmitPrefix implements 0007-n-tuple-omit-prefix-storage-layout
 type LayoutTupleOmitPrefix struct {
+	Base
 	Delimiter string `json:"delimiter"`
 	TupleSize int    `json:"tupleSize"`
 	TupleNum  int    `json:"numberOfTuples"`
@@ -34,6 +35,7 @@ var _ (Extension) = (*LayoutTupleOmitPrefix)(nil)
 // Ext0007 returns a new instance of 0007-n-tuple-omit-prefix-storage-layout with default values
 func Ext0007() Extension {
 	return &LayoutTupleOmitPrefix{
+		Base:      Base{ExtensionName: ext0007},
 		Delimiter: `:`,
 		TupleSize: 3,
 		TupleNum:  3,
@@ -41,8 +43,6 @@ func Ext0007() Extension {
 		Reverse:   false,
 	}
 }
-
-func (l LayoutTupleOmitPrefix) Name() string { return ext0007 }
 
 func (l LayoutTupleOmitPrefix) Documentation() []byte { return ext0007doc }
 

--- a/extension/0007_layout_tuple_omit_prefix_test.go
+++ b/extension/0007_layout_tuple_omit_prefix_test.go
@@ -36,7 +36,7 @@ func TestLayoutTupleOmitPrefix(t *testing.T) {
 	}
 
 	t.Run("unmarshal", func(t *testing.T) {
-		reg := extension.DefaultRegister()
+		reg := extension.DefaultRegistry()
 		ext, err := reg.Unmarshal([]byte(`{
 			"delimiter": ":",
 			"extensionName": "0007-n-tuple-omit-prefix-storage-layout",

--- a/extension/0007_layout_tuple_omit_prefix_test.go
+++ b/extension/0007_layout_tuple_omit_prefix_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/srerickson/ocfl-go/extension"
 )
 
+var _ (extension.Layout) = (*extension.LayoutTupleOmitPrefix)(nil)
+var _ (extension.Extension) = (*extension.LayoutTupleOmitPrefix)(nil)
+
 func TestLayoutTupleOmitPrefix(t *testing.T) {
 	layout := extension.Ext0007().(*extension.LayoutTupleOmitPrefix)
 	layout.TupleSize = 4

--- a/extension/0009_digest_algorithms.go
+++ b/extension/0009_digest_algorithms.go
@@ -7,7 +7,7 @@ import (
 const ext0009 = "0009-digest-algorithms"
 
 func Ext0009() Extension {
-	ext := algRegistry{
+	ext := &algRegistry{
 		Base: Base{ExtensionName: ext0009},
 	}
 	ext.algs = digest.NewRegistry(

--- a/extension/0009_digest_algorithms.go
+++ b/extension/0009_digest_algorithms.go
@@ -11,11 +11,11 @@ func Ext0009() Extension {
 		Base: Base{ExtensionName: ext0009},
 	}
 	ext.algs = digest.NewRegistry(
-		&alg{id: "blake2b-160", ext: ext},
-		&alg{id: "blake2b-256", ext: ext},
-		&alg{id: "blake2b-384", ext: ext},
-		&alg{id: "sha512/256", ext: ext},
-		&alg{id: "size", ext: ext},
+		&alg{Algorithm: digest.BLAKE2B_160, ext: ext},
+		&alg{Algorithm: digest.BLAKE2B_256, ext: ext},
+		&alg{Algorithm: digest.BLAKE2B_384, ext: ext},
+		&alg{Algorithm: digest.SHA512_256, ext: ext},
+		&alg{Algorithm: digest.SIZE, ext: ext},
 	)
 	return ext
 }

--- a/extension/0009_digest_algorithms.go
+++ b/extension/0009_digest_algorithms.go
@@ -10,7 +10,7 @@ func Ext0009() Extension {
 	ext := &algRegistry{
 		Base: Base{ExtensionName: ext0009},
 	}
-	ext.algs = digest.NewRegistry(
+	ext.algs = digest.NewAlgorithmRegistry(
 		&alg{Algorithm: digest.BLAKE2B_160, ext: ext},
 		&alg{Algorithm: digest.BLAKE2B_256, ext: ext},
 		&alg{Algorithm: digest.BLAKE2B_384, ext: ext},

--- a/extension/0009_digest_algorithms.go
+++ b/extension/0009_digest_algorithms.go
@@ -1,0 +1,38 @@
+package extension
+
+import (
+	_ "embed"
+
+	"github.com/srerickson/ocfl-go/digest"
+)
+
+const ext0009 = "0009-digest-algorithms"
+
+var (
+	Ext009AlgBlake2B_160 = &alg{id: "blake2b-160", ext: ExtraDigestAlgorithms{}}
+	Ext009AlgBlake2B_256 = &alg{id: "blake2b-256", ext: ExtraDigestAlgorithms{}}
+	Ext009AlgBlake2B_384 = &alg{id: "blake2b-384", ext: ExtraDigestAlgorithms{}}
+	Ext009AlgSHA512_256  = &alg{id: "sha512/256", ext: ExtraDigestAlgorithms{}}
+	Ext009AlgSize        = &alg{id: "size", ext: ExtraDigestAlgorithms{}}
+
+	ext0009Algs = digest.NewRegistry(
+		Ext009AlgBlake2B_160,
+		Ext009AlgBlake2B_256,
+		Ext009AlgBlake2B_384,
+		Ext009AlgSHA512_256,
+		Ext009AlgSize)
+
+	//go:embed docs/0007-n-tuple-omit-prefix-storage-layout.md
+	ext0009doc []byte
+)
+
+func Ext0009() Extension { return ExtraDigestAlgorithms{} }
+
+// ExtraDigestAlgorithms implements 0009-digest-algorithms
+type ExtraDigestAlgorithms struct{}
+
+func (d ExtraDigestAlgorithms) Name() string { return ext0009 }
+
+func (d ExtraDigestAlgorithms) Algorithms() digest.Registry {
+	return ext0009Algs
+}

--- a/extension/0009_digest_algorithms.go
+++ b/extension/0009_digest_algorithms.go
@@ -1,19 +1,14 @@
 package extension
 
 import (
-	_ "embed"
-
 	"github.com/srerickson/ocfl-go/digest"
 )
 
-const ext0009name = "0009-digest-algorithms"
+const ext0009 = "0009-digest-algorithms"
 
-//go:embed docs/0009-digest-algorithms.md
-var ext0009doc []byte
-
-func Ext0009() AlgorithmRegistry {
+func Ext0009() Extension {
 	ext := algRegistry{
-		Base: Base{ExtensionName: ext0009name},
+		Base: Base{ExtensionName: ext0009},
 	}
 	ext.algs = digest.NewRegistry(
 		&alg{id: "blake2b-160", ext: ext},

--- a/extension/0009_digest_algorithms_test.go
+++ b/extension/0009_digest_algorithms_test.go
@@ -1,0 +1,31 @@
+package extension_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/carlmjohnson/be"
+	"github.com/srerickson/ocfl-go/extension"
+)
+
+func TestExt0009DigestAlgorithms(t *testing.T) {
+	t.Run("digest values", func(t *testing.T) {
+		algExt, ok := extension.Ext0009().(extension.AlgorithmRegistry)
+		be.True(t, ok)
+		hashData := []byte("hello world")
+		table := map[string]string{
+			"blake2b-160": "70e8ece5e293e1bda064deef6b080edde357010f",
+			"blake2b-256": "256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610",
+			"blake2b-384": "8c653f8c9c9aa2177fb6f8cf5bb914828faa032d7b486c8150663d3f6524b086784f8e62693171ac51fc80b7d2cbb12b",
+			"sha512/256":  "0ac561fac838104e3f2e4ad107b4bee3e938bf15f2b15f009ccccd61a913f017",
+			"size":        fmt.Sprintf("%d", len(hashData)),
+		}
+		for id, digest := range table {
+			t.Run(id, func(t *testing.T) {
+				digester := algExt.Algorithms().MustGet(id).Digester()
+				digester.Write(hashData)
+				be.Equal(t, digest, digester.String())
+			})
+		}
+	})
+}

--- a/extension/algorithm.go
+++ b/extension/algorithm.go
@@ -16,6 +16,8 @@ import (
 // Algorithm is a digest.Algorithm provided by an extension
 type Algorithm interface {
 	digest.Algorithm
+	// Extension returns the AlgorithRegistry extension that provides the
+	// algorithm.
 	Extension() AlgorithmRegistry
 }
 

--- a/extension/algorithm.go
+++ b/extension/algorithm.go
@@ -19,15 +19,25 @@ type Algorithm interface {
 	Extension() AlgorithmRegistry
 }
 
-// AlgorithmRegistry is an extension that provides a collection of digest
+// AlgorithmRegistry is an extension that provides a registry of digest
 // algorithms
 type AlgorithmRegistry interface {
 	Extension
 	Algorithms() digest.Registry
 }
 
+// algRegistry is an implementation of AlgorithmRegistry
+type algRegistry struct {
+	Base
+	algs digest.Registry
+}
+
+// Algorithms implements DigestAlgorithms for digestAlgorithms
+func (d algRegistry) Algorithms() digest.Registry { return d.algs }
+
+// alg is an implementation of Algorithm used by all extension digest algorithms
 type alg struct {
-	id  string
+	id  string // digest algorithm's id ("size")
 	ext AlgorithmRegistry
 }
 
@@ -38,9 +48,9 @@ func (a alg) Digester() digest.Digester {
 	case "blake2b-160":
 		return &hashDigester{Hash: mustNewBlake2B(20)}
 	case "blake2b-256":
-		return &hashDigester{Hash: mustNewBlake2B(20)}
+		return &hashDigester{Hash: mustNewBlake2B(32)}
 	case "blake2b-384":
-		return &hashDigester{Hash: mustNewBlake2B(20)}
+		return &hashDigester{Hash: mustNewBlake2B(48)}
 	case "sha512/256":
 		return &hashDigester{Hash: sha512.New512_256()}
 	case "size":

--- a/extension/algorithm.go
+++ b/extension/algorithm.go
@@ -23,17 +23,17 @@ type Algorithm interface {
 // algorithms
 type AlgorithmRegistry interface {
 	Extension
-	Algorithms() digest.Registry
+	Algorithms() digest.AlgorithmRegistry
 }
 
 // algRegistry is an implementation of AlgorithmRegistry
 type algRegistry struct {
 	Base
-	algs digest.Registry
+	algs digest.AlgorithmRegistry
 }
 
 // Algorithms implements DigestAlgorithms for digestAlgorithms
-func (d algRegistry) Algorithms() digest.Registry { return d.algs }
+func (d algRegistry) Algorithms() digest.AlgorithmRegistry { return d.algs }
 
 // alg is an implementation of Algorithm used by all extension digest algorithms
 type alg struct {

--- a/extension/algorithm.go
+++ b/extension/algorithm.go
@@ -1,0 +1,100 @@
+package extension
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"hash"
+	"strconv"
+
+	"github.com/srerickson/ocfl-go/digest"
+	"golang.org/x/crypto/blake2b"
+)
+
+// Algorithm is a digest.Algorithm provided by an extension
+type Algorithm interface {
+	digest.Algorithm
+	Extension() AlgorithmRegistry
+}
+
+// AlgorithmRegistry is an extension that provides a collection of digest
+// algorithms
+type AlgorithmRegistry interface {
+	Extension
+	Algorithms() digest.Registry
+}
+
+type alg struct {
+	id  string
+	ext AlgorithmRegistry
+}
+
+func (a alg) ID() string { return a.id }
+
+func (a alg) Digester() digest.Digester {
+	switch a.id {
+	case "blake2b-160":
+		return &hashDigester{Hash: mustNewBlake2B(20)}
+	case "blake2b-256":
+		return &hashDigester{Hash: mustNewBlake2B(20)}
+	case "blake2b-384":
+		return &hashDigester{Hash: mustNewBlake2B(20)}
+	case "sha512/256":
+		return &hashDigester{Hash: sha512.New512_256()}
+	case "size":
+		return &sizeDigester{}
+	default:
+		panic("invalid algorithm id: " + a.id)
+	}
+}
+
+// hashDigester implements Digester using a hash.Hash
+type hashDigester struct {
+	hash.Hash
+}
+
+func (h hashDigester) String() string {
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// sizeDigester implements a Digester that counts bytes
+type sizeDigester struct {
+	size int64
+}
+
+func (d *sizeDigester) Write(b []byte) (int, error) {
+	l := len(b)
+	d.size += int64(l)
+	return l, nil
+}
+
+func (d *sizeDigester) String() string {
+	return strconv.FormatInt(d.size, 10)
+}
+
+func getHash(name string) hash.Hash {
+	switch name {
+	case `sha512`:
+		return sha512.New()
+	case `sha256`:
+		return sha256.New()
+	case `sha1`:
+		return sha1.New()
+	case `md5`:
+		return md5.New()
+	case `blake2b-512`:
+		return mustNewBlake2B(64)
+	default:
+		return nil
+	}
+}
+
+func mustNewBlake2B(size int) hash.Hash {
+	h, err := blake2b.New(size, nil)
+	if err != nil {
+		panic("creating new blake2b hash")
+	}
+	return h
+}

--- a/extension/algorithm.go
+++ b/extension/algorithm.go
@@ -5,9 +5,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
-	"encoding/hex"
 	"hash"
-	"strconv"
 
 	"github.com/srerickson/ocfl-go/digest"
 	"golang.org/x/crypto/blake2b"
@@ -39,51 +37,8 @@ func (d algRegistry) Algorithms() digest.Registry { return d.algs }
 
 // alg is an implementation of Algorithm used by all extension digest algorithms
 type alg struct {
-	id  string // digest algorithm's id ("size")
+	digest.Algorithm
 	ext AlgorithmRegistry
-}
-
-func (a alg) ID() string { return a.id }
-
-func (a alg) Digester() digest.Digester {
-	switch a.id {
-	case "blake2b-160":
-		return &hashDigester{Hash: mustNewBlake2B(20)}
-	case "blake2b-256":
-		return &hashDigester{Hash: mustNewBlake2B(32)}
-	case "blake2b-384":
-		return &hashDigester{Hash: mustNewBlake2B(48)}
-	case "sha512/256":
-		return &hashDigester{Hash: sha512.New512_256()}
-	case "size":
-		return &sizeDigester{}
-	default:
-		panic("invalid algorithm id: " + a.id)
-	}
-}
-
-// hashDigester implements Digester using a hash.Hash
-type hashDigester struct {
-	hash.Hash
-}
-
-func (h hashDigester) String() string {
-	return hex.EncodeToString(h.Sum(nil))
-}
-
-// sizeDigester implements a Digester that counts bytes
-type sizeDigester struct {
-	size int64
-}
-
-func (d *sizeDigester) Write(b []byte) (int, error) {
-	l := len(b)
-	d.size += int64(l)
-	return l, nil
-}
-
-func (d *sizeDigester) String() string {
-	return strconv.FormatInt(d.size, 10)
 }
 
 func getHash(name string) hash.Hash {

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -1,6 +1,7 @@
 package extension
 
 import (
+	"embed"
 	"errors"
 )
 
@@ -17,18 +18,24 @@ var (
 
 	// built-in extensions
 	baseExtensions = []func() Extension{
+		Ext0001,
 		Ext0002,
 		Ext0003,
 		Ext0004,
 		Ext0006,
 		Ext0007,
+		Ext0009,
 	}
+
+	//go:embed docs
+	docs embed.FS
 )
 
 // Extension is implemented by types that represent specific OCFL Extensions.
 // See https://github.com/OCFL/extensions
 type Extension interface {
 	Name() string // Name returns the extension name
+	Doc() string  // Extension documentation in markdown format (if available)
 }
 
 // Base is a type that can be embedded by types that implement
@@ -38,6 +45,16 @@ type Base struct {
 }
 
 func (b Base) Name() string { return string(b.ExtensionName) }
+
+// Doc returns documentation string (markdown format) for the extension, if
+// available.
+func (b Base) Doc() string {
+	byts, err := docs.ReadFile("docs/" + b.ExtensionName + ".md")
+	if err != nil {
+		return ""
+	}
+	return string(byts)
+}
 
 // Layout is an extension that provides a function for resolving object IDs to
 // Storage Root Paths

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -1,15 +1,7 @@
 package extension
 
 import (
-	"crypto/md5"
-	"crypto/sha1"
-	"crypto/sha256"
-	"crypto/sha512"
 	"errors"
-	"hash"
-
-	"github.com/srerickson/ocfl-go/digest"
-	"golang.org/x/crypto/blake2b"
 )
 
 const (
@@ -47,32 +39,4 @@ type Layout interface {
 	Resolve(id string) (path string, err error)
 	// Valid returns an error if the layout configuation is invalid
 	Valid() error
-}
-
-// DigestAlgorithm is an extension that provides a collection of availble
-// digest algorithms
-type DigestAlgorithm interface {
-	Extension
-	Algorithms() digest.Register
-}
-
-func getAlg(name string) hash.Hash {
-	switch name {
-	case `sha512`:
-		return sha512.New()
-	case `sha256`:
-		return sha256.New()
-	case `sha1`:
-		return sha1.New()
-	case `md5`:
-		return md5.New()
-	case `blake2b-512`:
-		h, err := blake2b.New512(nil)
-		if err != nil {
-			panic("creating new blake2b hash")
-		}
-		return h
-	default:
-		return nil
-	}
 }

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -31,6 +31,14 @@ type Extension interface {
 	Name() string // Name returns the extension name
 }
 
+// Base is a type that can be embedded by types that implement
+// the Extension.
+type Base struct {
+	ExtensionName string `json:"extensionName"`
+}
+
+func (b Base) Name() string { return string(b.ExtensionName) }
+
 // Layout is an extension that provides a function for resolving object IDs to
 // Storage Root Paths
 type Layout interface {

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"hash"
 
+	"github.com/srerickson/ocfl-go/digest"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -46,6 +47,13 @@ type Layout interface {
 	Resolve(id string) (path string, err error)
 	// Valid returns an error if the layout configuation is invalid
 	Valid() error
+}
+
+// DigestAlgorithm is an extension that provides a collection of availble
+// digest algorithms
+type DigestAlgorithm interface {
+	Extension
+	Algorithms() digest.Register
 }
 
 func getAlg(name string) hash.Hash {

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -1,21 +1,19 @@
 package extension_test
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/carlmjohnson/be"
 	"github.com/srerickson/ocfl-go/extension"
 	"github.com/srerickson/ocfl-go/internal/testutil"
 )
 
-func testLayoutExt(t *testing.T, layout extension.Layout, in, out string) {
+func testLayoutExt(t *testing.T, layout extension.Layout, in, expect string) {
 	t.Helper()
 	got, err := layout.Resolve(in)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != out {
-		t.Fatalf("expected %s, got %s", out, got)
-	}
+	be.NilErr(t, err)
+	be.Equal(t, expect, got)
 }
 
 func TestCustomLayout(t *testing.T) {
@@ -26,19 +24,17 @@ func TestCustomLayout(t *testing.T) {
 		"prefix": "test_objects"
 	}`)
 	ext, err := reg.Unmarshal(layoutJSON)
-	if err != nil {
-		t.Fatal("extension.UnmarshalLayout()", err)
-	}
+	be.NilErr(t, err)
 	layout, ok := ext.(extension.Layout)
-	if !ok {
-		t.Fatal("not a layout")
-	}
+	be.True(t, ok)
 	result, err := layout.Resolve("object-01")
-	if err != nil {
-		t.Fatal("Resolve()", err)
-	}
+	be.NilErr(t, err)
 	expect := "test_objects/object-01"
-	if result != expect {
-		t.Errorf("Resolve(): got=%q, expected=%q", result, expect)
-	}
+	be.Equal(t, expect, result)
+	// encode custom extension
+	encJSON, err := json.Marshal(ext)
+	be.NilErr(t, err)
+	ext2, err := reg.Unmarshal(encJSON)
+	be.NilErr(t, err)
+	be.Equal(t, ext.Name(), ext2.Name())
 }

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -19,7 +19,7 @@ func testLayoutExt(t *testing.T, layout extension.Layout, in, out string) {
 }
 
 func TestCustomLayout(t *testing.T) {
-	reg := extension.NewRegister(testutil.NewCustomLayout)
+	reg := extension.NewRegistry(testutil.NewCustomLayout)
 	name := testutil.NewCustomLayout().Name()
 	layoutJSON := []byte(`{
 		"extensionName": "` + name + `",

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -38,3 +38,20 @@ func TestCustomLayout(t *testing.T) {
 	be.NilErr(t, err)
 	be.Equal(t, ext.Name(), ext2.Name())
 }
+
+func TestExtensionUnmarshal(t *testing.T) {
+	registry := extension.DefaultRegistry()
+	allExtensions := registry.Names()
+	be.Equal(t, 7, len(allExtensions))
+	for _, extName := range allExtensions {
+		ext, err := registry.New(extName)
+		be.NilErr(t, err)
+		be.Equal(t, extName, ext.Name())
+		be.Nonzero(t, ext.Doc())
+		jsonEnc, err := json.Marshal(ext)
+		be.NilErr(t, err)
+		ext2, err := registry.Unmarshal(jsonEnc)
+		be.NilErr(t, err)
+		be.Equal(t, extName, ext2.Name())
+	}
+}

--- a/extension/registry_test.go
+++ b/extension/registry_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestUnmarshalJSON(t *testing.T) {
-	reg := extension.DefaultRegister()
+	reg := extension.DefaultRegistry()
 	names := reg.Names()
 	if len(names) == 0 {
 		t.Fatal("expected > 0 registered extensions")
@@ -24,7 +24,7 @@ func TestUnmarshalJSON(t *testing.T) {
 
 func TestMarshalJSON(t *testing.T) {
 	// Test json encoding for all registered extensions.
-	reg := extension.DefaultRegister()
+	reg := extension.DefaultRegistry()
 	for _, name := range reg.Names() {
 		ext, err := extension.Get(name)
 		if err != nil {

--- a/internal/pipeline/pipeline_example_test.go
+++ b/internal/pipeline/pipeline_example_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/srerickson/ocfl-go"
+	"github.com/srerickson/ocfl-go/digest"
 	"github.com/srerickson/ocfl-go/internal/pipeline"
 )
 
@@ -38,7 +38,7 @@ func ExampleResults() {
 			return r, err
 		}
 		defer f.Close()
-		dig := ocfl.NewMultiDigester(alg)
+		dig := digest.NewMultiDigester(alg)
 		if _, err := io.Copy(dig, f); err != nil {
 			return r, err
 		}

--- a/internal/pipeline/pipeline_example_test.go
+++ b/internal/pipeline/pipeline_example_test.go
@@ -38,7 +38,10 @@ func ExampleResults() {
 			return r, err
 		}
 		defer f.Close()
-		dig := digest.NewMultiDigester(alg)
+		dig, err := digest.NewMultiDigester(alg)
+		if err != nil {
+			return r, err
+		}
 		if _, err := io.Copy(dig, f); err != nil {
 			return r, err
 		}

--- a/internal/pipeline/pipeline_example_test.go
+++ b/internal/pipeline/pipeline_example_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/srerickson/ocfl-go/internal/pipeline"
 )
 
-var alg = `sha256`
+var alg = digest.SHA256
 
 func ExampleResults() {
 	fsys := os.DirFS(".")
@@ -38,14 +38,11 @@ func ExampleResults() {
 			return r, err
 		}
 		defer f.Close()
-		dig, err := digest.NewMultiDigester(alg)
-		if err != nil {
-			return r, err
-		}
+		dig := digest.NewMultiDigester(alg)
 		if _, err := io.Copy(dig, f); err != nil {
 			return r, err
 		}
-		r.sum = dig.Sums()[alg]
+		r.sum = dig.Sums()[alg.ID()]
 		return r, nil
 	}
 	pipeline.Results(inputFn, workFn, 0)(func(r pipeline.Result[job, result]) bool {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -68,9 +68,6 @@ func BenchmarkPipeline(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	pipeline.Results(input, run, 0)(func(r pipeline.Result[job, result]) bool {
-		if r.Err != nil {
-			return false
-		}
-		return true
+		return r.Err == nil
 	})
 }

--- a/internal/testutil/custom_layout.go
+++ b/internal/testutil/custom_layout.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"encoding/json"
 	"net/url"
 	"path"
 
@@ -15,16 +14,21 @@ const (
 
 func NewCustomLayout() extension.Extension {
 	return &CustomLayout{
+		Base:   extension.Base{ExtensionName: customExtensionName},
 		Prefix: "",
 	}
 }
 
 // CustomLayout implements extension.Layout
 type CustomLayout struct {
+	extension.Base
 	Prefix string `json:"prefix"`
 }
 
 var _ extension.Layout = (*CustomLayout)(nil)
+
+func (l CustomLayout) Name() string { return customExtensionName }
+func (l CustomLayout) Doc() string  { return "" }
 
 func (l CustomLayout) Resolve(id string) (string, error) {
 	return path.Join(l.Prefix, url.QueryEscape(id)), nil
@@ -33,12 +37,3 @@ func (l CustomLayout) Resolve(id string) (string, error) {
 func (l CustomLayout) Valid() error {
 	return nil
 }
-
-func (l CustomLayout) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]string{
-		"extensionName": customExtensionName,
-		"prefix":        l.Prefix,
-	})
-}
-
-func (l CustomLayout) Name() string { return customExtensionName }

--- a/inventory.go
+++ b/inventory.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/srerickson/ocfl-go/digest"
 )
 
 var (
@@ -75,7 +77,7 @@ func ValidateInventorySidecar(ctx context.Context, inv ReadInventory, fsys FS, d
 		return err
 	}
 	if !strings.EqualFold(expSum, inv.Digest()) {
-		return &DigestError{
+		return &digest.DigestError{
 			Path:     sideCar,
 			Alg:      inv.DigestAlgorithm(),
 			Got:      inv.Digest(),

--- a/inventory.go
+++ b/inventory.go
@@ -25,7 +25,7 @@ type ReadInventory interface {
 	FixitySource
 	ContentDirectory() string
 	Digest() string
-	DigestAlgorithm() string
+	DigestAlgorithm() digest.Algorithm
 	Head() VNum
 	ID() string
 	Manifest() DigestMap
@@ -71,7 +71,7 @@ func ReadSidecarDigest(ctx context.Context, fsys FS, name string) (digest string
 // if the sidecar content is not formatted correctly or if the inv's digest
 // doesn't match the value found in the sidecar.
 func ValidateInventorySidecar(ctx context.Context, inv ReadInventory, fsys FS, dir string) error {
-	sideCar := path.Join(dir, inventoryBase+"."+inv.DigestAlgorithm())
+	sideCar := path.Join(dir, inventoryBase+"."+inv.DigestAlgorithm().ID())
 	expSum, err := ReadSidecarDigest(ctx, fsys, sideCar)
 	if err != nil {
 		return err
@@ -79,7 +79,7 @@ func ValidateInventorySidecar(ctx context.Context, inv ReadInventory, fsys FS, d
 	if !strings.EqualFold(expSum, inv.Digest()) {
 		return &digest.DigestError{
 			Path:     sideCar,
-			Alg:      inv.DigestAlgorithm(),
+			Alg:      inv.DigestAlgorithm().ID(),
 			Got:      inv.Digest(),
 			Expected: expSum,
 		}

--- a/inventory.go
+++ b/inventory.go
@@ -32,6 +32,7 @@ type ReadInventory interface {
 	Spec() Spec
 	Validate() *Validation
 	Version(int) ObjectVersion
+	FixityAlgorithms() []string
 }
 
 type ObjectVersion interface {

--- a/object.go
+++ b/object.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"log/slog"
+
+	"github.com/srerickson/ocfl-go/digest"
 )
 
 // Object represents and OCFL Object, typically contained in a Root. An Object
@@ -295,7 +297,7 @@ func (vfs *ObjectVersionFS) Close() error {
 	return nil
 }
 func (vfs *ObjectVersionFS) Created() time.Time                { return vfs.ver.Created() }
-func (vfs *ObjectVersionFS) DigestAlgorithm() string           { return vfs.inv.DigestAlgorithm() }
+func (vfs *ObjectVersionFS) DigestAlgorithm() digest.Algorithm { return vfs.inv.DigestAlgorithm() }
 func (vfs *ObjectVersionFS) State() DigestMap                  { return vfs.ver.State() }
 func (vfs *ObjectVersionFS) Message() string                   { return vfs.ver.Message() }
 func (vfs *ObjectVersionFS) Num() int                          { return vfs.num }

--- a/object_test.go
+++ b/object_test.go
@@ -45,7 +45,7 @@ func testObjectExample(t *testing.T) {
 	v1Content := map[string][]byte{
 		"README.txt": []byte("this is a test file"),
 	}
-	stage, err := ocfl.StageBytes(v1Content, digest.SHA512.ID(), digest.MD5.ID())
+	stage, err := ocfl.StageBytes(v1Content, digest.SHA512, digest.MD5)
 	be.NilErr(t, err)
 	err = obj.Commit(ctx, &ocfl.Commit{
 		Spec:    ocfl.Spec1_0,
@@ -67,7 +67,7 @@ func testObjectExample(t *testing.T) {
 		"new-data.csv":  []byte("1,2,3"),
 		"docs/note.txt": []byte("this is a note"),
 	}
-	stage, err = ocfl.StageBytes(v2Content, digest.SHA512.ID(), digest.MD5.ID())
+	stage, err = ocfl.StageBytes(v2Content, digest.SHA512, digest.MD5)
 	be.NilErr(t, err)
 	err = obj.Commit(ctx, &ocfl.Commit{
 		ID:      "new-object-01",
@@ -187,7 +187,7 @@ func testObjectCommit(t *testing.T) {
 		be.False(t, obj.Exists())
 		commit := &ocfl.Commit{
 			ID:      "new-object",
-			Stage:   &ocfl.Stage{State: ocfl.DigestMap{}, DigestAlgorithm: digest.SHA256.ID()},
+			Stage:   &ocfl.Stage{State: ocfl.DigestMap{}, DigestAlgorithm: digest.SHA256},
 			Message: "new object",
 			User: ocfl.User{
 				Name: "Anna Karenina",
@@ -206,7 +206,7 @@ func testObjectCommit(t *testing.T) {
 		be.False(t, obj.Exists())
 		commit := &ocfl.Commit{
 			ID:      "new-object",
-			Stage:   &ocfl.Stage{State: ocfl.DigestMap{}, DigestAlgorithm: digest.SHA512.ID()},
+			Stage:   &ocfl.Stage{State: ocfl.DigestMap{}, DigestAlgorithm: digest.SHA512},
 			Message: "new object",
 			User: ocfl.User{
 				Name: "Anna Karenina",
@@ -214,7 +214,7 @@ func testObjectCommit(t *testing.T) {
 			Spec: ocfl.Spec1_0,
 		}
 		be.NilErr(t, obj.Commit(ctx, commit))
-		commit.Stage.DigestAlgorithm = digest.SHA256.ID()
+		commit.Stage.DigestAlgorithm = digest.SHA256
 		err = obj.Commit(ctx, commit)
 		be.True(t, err != nil)
 		be.True(t, strings.Contains(err.Error(), "must use same digest algorithm as existing inventory"))

--- a/object_test.go
+++ b/object_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/carlmjohnson/be"
 	"github.com/srerickson/ocfl-go"
 	"github.com/srerickson/ocfl-go/backend/local"
+	"github.com/srerickson/ocfl-go/digest"
 	"github.com/srerickson/ocfl-go/ocflv1"
 	"golang.org/x/exp/maps"
 )
@@ -44,7 +45,7 @@ func testObjectExample(t *testing.T) {
 	v1Content := map[string][]byte{
 		"README.txt": []byte("this is a test file"),
 	}
-	stage, err := ocfl.StageBytes(v1Content, ocfl.SHA512, ocfl.MD5)
+	stage, err := ocfl.StageBytes(v1Content, digest.SHA512.ID(), digest.MD5.ID())
 	be.NilErr(t, err)
 	err = obj.Commit(ctx, &ocfl.Commit{
 		Spec:    ocfl.Spec1_0,
@@ -66,7 +67,7 @@ func testObjectExample(t *testing.T) {
 		"new-data.csv":  []byte("1,2,3"),
 		"docs/note.txt": []byte("this is a note"),
 	}
-	stage, err = ocfl.StageBytes(v2Content, ocfl.SHA512, ocfl.MD5)
+	stage, err = ocfl.StageBytes(v2Content, digest.SHA512.ID(), digest.MD5.ID())
 	be.NilErr(t, err)
 	err = obj.Commit(ctx, &ocfl.Commit{
 		ID:      "new-object-01",
@@ -186,7 +187,7 @@ func testObjectCommit(t *testing.T) {
 		be.False(t, obj.Exists())
 		commit := &ocfl.Commit{
 			ID:      "new-object",
-			Stage:   &ocfl.Stage{State: ocfl.DigestMap{}, DigestAlgorithm: ocfl.SHA256},
+			Stage:   &ocfl.Stage{State: ocfl.DigestMap{}, DigestAlgorithm: digest.SHA256.ID()},
 			Message: "new object",
 			User: ocfl.User{
 				Name: "Anna Karenina",
@@ -205,7 +206,7 @@ func testObjectCommit(t *testing.T) {
 		be.False(t, obj.Exists())
 		commit := &ocfl.Commit{
 			ID:      "new-object",
-			Stage:   &ocfl.Stage{State: ocfl.DigestMap{}, DigestAlgorithm: ocfl.SHA512},
+			Stage:   &ocfl.Stage{State: ocfl.DigestMap{}, DigestAlgorithm: digest.SHA512.ID()},
 			Message: "new object",
 			User: ocfl.User{
 				Name: "Anna Karenina",
@@ -213,7 +214,7 @@ func testObjectCommit(t *testing.T) {
 			Spec: ocfl.Spec1_0,
 		}
 		be.NilErr(t, obj.Commit(ctx, commit))
-		commit.Stage.DigestAlgorithm = ocfl.SHA256
+		commit.Stage.DigestAlgorithm = digest.SHA256.ID()
 		err = obj.Commit(ctx, commit)
 		be.True(t, err != nil)
 		be.True(t, strings.Contains(err.Error(), "must use same digest algorithm as existing inventory"))

--- a/ocfl.go
+++ b/ocfl.go
@@ -54,7 +54,7 @@ type OCFL interface {
 
 type Config struct {
 	ocfls *OCLFRegister
-	algs  digest.Register
+	algs  digest.Registry
 }
 
 func (c Config) OCFLs() *OCLFRegister {

--- a/ocfl.go
+++ b/ocfl.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+
+	"github.com/srerickson/ocfl-go/digest"
 )
 
 const (
@@ -52,6 +54,7 @@ type OCFL interface {
 
 type Config struct {
 	ocfls *OCLFRegister
+	algs  digest.Register
 }
 
 func (c Config) OCFLs() *OCLFRegister {

--- a/ocfl.go
+++ b/ocfl.go
@@ -11,8 +11,6 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
-
-	"github.com/srerickson/ocfl-go/digest"
 )
 
 const (
@@ -54,7 +52,7 @@ type OCFL interface {
 
 type Config struct {
 	ocfls *OCLFRegister
-	algs  digest.Registry
+	//algs  digest.Registry
 }
 
 func (c Config) OCFLs() *OCLFRegister {

--- a/ocflv1/inventory.go
+++ b/ocflv1/inventory.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/srerickson/ocfl-go"
+	"github.com/srerickson/ocfl-go/digest"
 	"github.com/srerickson/ocfl-go/ocflv1/codes"
 	"golang.org/x/exp/maps"
 )
@@ -166,13 +167,13 @@ func (inv *Inventory) Validate() *ocfl.Validation {
 		v.AddWarn(ec(err, codes.W005(ocflV)))
 	}
 	switch inv.DigestAlgorithm {
-	case ocfl.SHA512:
+	case digest.SHA512.ID():
 		break
-	case ocfl.SHA256:
-		err := fmt.Errorf(`'digestAlgorithm' is %q`, ocfl.SHA256)
+	case digest.SHA256.ID():
+		err := fmt.Errorf(`'digestAlgorithm' is %q`, digest.SHA256.ID())
 		v.AddWarn(ec(err, codes.W004(ocflV)))
 	default:
-		err := fmt.Errorf(`'digestAlgorithm' is not %q or %q`, ocfl.SHA512, ocfl.SHA256)
+		err := fmt.Errorf(`'digestAlgorithm' is not %q or %q`, digest.SHA512.ID(), digest.SHA256.ID())
 		v.AddFatal(ec(err, codes.E025(ocflV)))
 	}
 	if err := inv.Head.Valid(); err != nil {
@@ -371,7 +372,7 @@ func ValidateInventoryBytes(raw []byte, spec ocfl.Spec) (inv *Inventory, v *ocfl
 		err := errors.New(requiredErrMsg + `: 'digestAlgorithm'`)
 		v.AddFatal(ec(err, codes.E036(spec)))
 	}
-	if digestAlg != "" && digestAlg != ocfl.SHA512 && digestAlg != ocfl.SHA256 {
+	if digestAlg != "" && digestAlg != digest.SHA512.ID() && digestAlg != digest.SHA256.ID() {
 		err := fmt.Errorf("invalid digest algorithm: %q", digestAlg)
 		v.AddFatal(ec(err, codes.E025(spec)))
 	}

--- a/ocflv1/inventory.go
+++ b/ocflv1/inventory.go
@@ -314,7 +314,7 @@ func (inv *Inventory) Validate() *ocfl.Validation {
 }
 
 func (inv *Inventory) setJsonDigest(raw []byte) error {
-	digester, err := digest.NewDigester(inv.DigestAlgorithm)
+	digester, err := digest.DefaultRegistry().NewDigester(inv.DigestAlgorithm)
 	if err != nil {
 		return err
 	}
@@ -754,6 +754,17 @@ func (inv *readInventory) DigestAlgorithm() digest.Algorithm {
 	default:
 		return nil
 	}
+}
+
+func (inv *readInventory) FixityAlgorithms() []string {
+	if len(inv.raw.Fixity) < 1 {
+		return nil
+	}
+	algs := make([]string, 0, len(inv.raw.Fixity))
+	for alg := range inv.raw.Fixity {
+		algs = append(algs, alg)
+	}
+	return algs
 }
 
 func (inv *readInventory) Head() ocfl.VNum { return inv.raw.Head }

--- a/ocflv1/inventory.go
+++ b/ocflv1/inventory.go
@@ -114,12 +114,12 @@ func (inv Inventory) Version(v int) *Version {
 }
 
 // GetFixity implements ocfl.FixitySource for Inventory
-func (inv Inventory) GetFixity(digest string) ocfl.DigestSet {
-	paths := inv.Manifest[digest]
+func (inv Inventory) GetFixity(dig string) digest.Set {
+	paths := inv.Manifest[dig]
 	if len(paths) < 1 {
 		return nil
 	}
-	set := ocfl.DigestSet{}
+	set := digest.Set{}
 	for fixAlg, fixMap := range inv.Fixity {
 		fixMap.EachPath(func(p, fixDigest string) bool {
 			if slices.Contains(paths, p) {
@@ -314,9 +314,9 @@ func (inv *Inventory) Validate() *ocfl.Validation {
 }
 
 func (inv *Inventory) setJsonDigest(raw []byte) error {
-	digester := ocfl.NewDigester(inv.DigestAlgorithm)
-	if digester == nil {
-		return fmt.Errorf("%w: %q", ocfl.ErrUnknownAlg, inv.DigestAlgorithm)
+	digester, err := digest.NewDigester(inv.DigestAlgorithm)
+	if err != nil {
+		return err
 	}
 	if _, err := io.Copy(digester, bytes.NewReader(raw)); err != nil {
 		return fmt.Errorf("digesting inventory: %w", err)
@@ -733,7 +733,7 @@ type readInventory struct {
 
 func (inv *readInventory) MarshalJSON() ([]byte, error) { return json.Marshal(inv.raw) }
 
-func (inv *readInventory) GetFixity(digest string) ocfl.DigestSet { return inv.raw.GetFixity(digest) }
+func (inv *readInventory) GetFixity(digest string) digest.Set { return inv.raw.GetFixity(digest) }
 
 func (inv *readInventory) ContentDirectory() string {
 	if c := inv.raw.ContentDirectory; c != "" {

--- a/ocflv1/ocflv1.go
+++ b/ocflv1/ocflv1.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/srerickson/ocfl-go"
+	"github.com/srerickson/ocfl-go/digest"
 	"github.com/srerickson/ocfl-go/extension"
 	"github.com/srerickson/ocfl-go/internal/pipeline"
 	"github.com/srerickson/ocfl-go/logging"
@@ -289,7 +290,7 @@ func (imp OCFL) ValidateObjectContent(ctx context.Context, obj ocfl.ReadObject, 
 		}
 		for result := range pipeline.Results(work, workFn, numWorkers) {
 			if result.Err != nil {
-				var digestErr *ocfl.DigestError
+				var digestErr *digest.DigestError
 				switch {
 				case errors.As(result.Err, &digestErr):
 					newVld.AddFatal(ec(digestErr, codes.E093(imp.spec)))

--- a/ocflv1/ocflv1.go
+++ b/ocflv1/ocflv1.go
@@ -291,7 +291,7 @@ func (imp OCFL) ValidateObjectContent(ctx context.Context, obj ocfl.ReadObject, 
 			if err != nil {
 				return false, err
 			}
-			if err := registry.Validate(f, pd.Digests); err != nil {
+			if err := pd.Digests.Validate(f, registry); err != nil {
 				f.Close()
 				var digestErr *digest.DigestError
 				if errors.As(err, &digestErr) {

--- a/root.go
+++ b/root.go
@@ -330,7 +330,7 @@ func readExtensionConfig(ctx context.Context, fsys FS, root string, name string)
 	if err != nil {
 		return nil, fmt.Errorf("reading config for extension %s: %w", name, err)
 	}
-	return extension.DefaultRegister().Unmarshal(b)
+	return extension.DefaultRegistry().Unmarshal(b)
 }
 
 // writeExtensionConfig writes the configuration files for the ext to the

--- a/root_test.go
+++ b/root_test.go
@@ -57,7 +57,7 @@ func TestRoot(t *testing.T) {
 		be.NilErr(t, err)
 		stage, err := ocfl.StageBytes(map[string][]byte{
 			"file.txt": []byte("readme readme readme"),
-		}, digest.SHA256.ID())
+		}, digest.SHA256)
 		be.NilErr(t, err)
 		err = obj.Commit(ctx, &ocfl.Commit{
 			Stage:   stage,

--- a/root_test.go
+++ b/root_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/carlmjohnson/be"
 	"github.com/srerickson/ocfl-go"
 	"github.com/srerickson/ocfl-go/backend/local"
+	"github.com/srerickson/ocfl-go/digest"
 	"github.com/srerickson/ocfl-go/extension"
 	"github.com/srerickson/ocfl-go/ocflv1"
 )
@@ -56,7 +57,7 @@ func TestRoot(t *testing.T) {
 		be.NilErr(t, err)
 		stage, err := ocfl.StageBytes(map[string][]byte{
 			"file.txt": []byte("readme readme readme"),
-		}, ocfl.SHA256)
+		}, digest.SHA256.ID())
 		be.NilErr(t, err)
 		err = obj.Commit(ctx, &ocfl.Commit{
 			Stage:   stage,

--- a/stage.go
+++ b/stage.go
@@ -150,8 +150,8 @@ func (ps fixitySources) GetFixity(dig string) digest.Set {
 // algs and added to the stage. The algs must include sha512 or sha256 or an
 // error is returned
 // FIXME: algs should be DigestAlgorithms, not strings
-func StageDir(ctx context.Context, fsys FS, dir string, algs ...string) (*Stage, error) {
-	if len(algs) < 1 || (algs[0] != digest.SHA512.ID() && algs[0] != digest.SHA256.ID()) {
+func StageDir(ctx context.Context, fsys FS, dir string, algs ...digest.Algorithm) (*Stage, error) {
+	if len(algs) < 1 || (algs[0].ID() != digest.SHA512.ID() && algs[0].ID() != digest.SHA256.ID()) {
 		return nil, fmt.Errorf("must use sha512 or sha256 as the primary digest algorithm for the stage")
 	}
 	if !fs.ValidPath(dir) {
@@ -164,7 +164,7 @@ func StageDir(ctx context.Context, fsys FS, dir string, algs ...string) (*Stage,
 		manifest: map[string]dirManifestEntry{},
 	}
 	var walkErr error
-	filesIter := func(yield func(name string, algs []string) bool) {
+	filesIter := func(yield func(name string, algs []digest.Algorithm) bool) {
 		for info, err := range Files(ctx, dirMan.fs, dir) {
 			if err != nil {
 				walkErr = err

--- a/stage.go
+++ b/stage.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"testing/fstest"
+
+	"github.com/srerickson/ocfl-go/digest"
 )
 
 // Stage is used to create/update objects.
@@ -42,7 +44,8 @@ func (s *Stage) Overlay(stages ...*Stage) error {
 	if s.State == nil {
 		s.State = DigestMap{}
 	}
-	if alg := s.DigestAlgorithm; alg == "" || (alg != SHA512 && alg != SHA256) {
+	// FIXME
+	if al := s.DigestAlgorithm; al == "" || (al != digest.SHA512.ID() && al != digest.SHA256.ID()) {
 		return errors.New("stage's digest algorithm must be 'sha512' or 'sha256'")
 	}
 	var err error
@@ -146,8 +149,9 @@ func (ps fixitySources) GetFixity(digest string) DigestSet {
 // All files in dir and its subdirectories are digested with the given digest
 // algs and added to the stage. The algs must include sha512 or sha256 or an
 // error is returned
+// FIXME: algs should be DigestAlgorithms, not strings
 func StageDir(ctx context.Context, fsys FS, dir string, algs ...string) (*Stage, error) {
-	if len(algs) < 1 || (algs[0] != SHA512 && algs[0] != SHA256) {
+	if len(algs) < 1 || (algs[0] != digest.SHA512.ID() && algs[0] != digest.SHA256.ID()) {
 		return nil, fmt.Errorf("must use sha512 or sha256 as the primary digest algorithm for the stage")
 	}
 	if !fs.ValidPath(dir) {

--- a/stage_test.go
+++ b/stage_test.go
@@ -13,11 +13,11 @@ import (
 func TestStageDir(t *testing.T) {
 	ctx := context.Background()
 	fsys := ocfl.DirFS("testdata")
-	stage, err := ocfl.StageDir(ctx, fsys, "content-fixture", digest.SHA256.ID(), digest.MD5.ID())
+	stage, err := ocfl.StageDir(ctx, fsys, "content-fixture", digest.SHA256, digest.MD5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stage.DigestAlgorithm != digest.SHA256.ID() {
+	if stage.DigestAlgorithm.ID() != digest.SHA256.ID() {
 		t.Fatalf("stage's alg isn't %s", digest.SHA256.ID())
 	}
 	expectedSize := 3

--- a/validation.go
+++ b/validation.go
@@ -79,6 +79,7 @@ type ObjectValidation struct {
 	skipDigests bool
 	concurrency int
 	files       map[string]*validationFileInfo
+	algRegister digest.Register
 }
 
 // NewObjectValidation constructs a new *Validation with the given
@@ -282,6 +283,13 @@ func ValidationLogger(logger *slog.Logger) ObjectValidationOption {
 func ValidationDigestConcurrency(num int) ObjectValidationOption {
 	return func(v *ObjectValidation) {
 		v.concurrency = num
+	}
+}
+
+// ValidateDigestAlgorithms is used to set the
+func ValidateDigestAlgorithms(algs ...digest.Alg) ObjectValidationOption {
+	return func(v *ObjectValidation) {
+		v.algRegister = digest.NewRegister(algs...)
 	}
 }
 

--- a/validation.go
+++ b/validation.go
@@ -79,13 +79,15 @@ type ObjectValidation struct {
 	skipDigests bool
 	concurrency int
 	files       map[string]*validationFileInfo
-	algRegister digest.Registry
+	algRegistry digest.Registry
 }
 
 // NewObjectValidation constructs a new *Validation with the given
 // options
 func NewObjectValidation(opts ...ObjectValidationOption) *ObjectValidation {
-	v := &ObjectValidation{}
+	v := &ObjectValidation{
+		algRegistry: digest.DefaultRegistry(),
+	}
 	for _, opt := range opts {
 		opt(v)
 	}
@@ -262,6 +264,13 @@ func (v *ObjectValidation) ExistingContentDigests() iter.Seq[PathDigests] {
 	}
 }
 
+// ValidationAlgorithms returns the registry of digest algoriths
+// the object validation is configured to use. The default value is
+// digest.DefaultRegistry
+func (v *ObjectValidation) ValidationAlgorithms() digest.Registry {
+	return v.algRegistry
+}
+
 type ObjectValidationOption func(*ObjectValidation)
 
 func ValidationSkipDigest() ObjectValidationOption {
@@ -286,10 +295,11 @@ func ValidationDigestConcurrency(num int) ObjectValidationOption {
 	}
 }
 
-// ValidateDigestAlgorithms is used to set the
-func ValidateDigestAlgorithms(algs ...digest.Algorithm) ObjectValidationOption {
+// ValidationAlgorithms sets registry of available digest algorithms for
+// fixity validation.
+func ValidationAlgorithms(reg digest.Registry) ObjectValidationOption {
 	return func(v *ObjectValidation) {
-		v.algRegister = digest.NewRegistry(algs...)
+		v.algRegistry = reg
 	}
 }
 

--- a/validation.go
+++ b/validation.go
@@ -78,7 +78,7 @@ type ObjectValidation struct {
 	skipDigests bool
 	concurrency int
 	files       map[string]*validationFileInfo
-	algRegistry digest.Registry
+	algRegistry digest.AlgorithmRegistry
 }
 
 // NewObjectValidation constructs a new *Validation with the given
@@ -266,7 +266,7 @@ func (v *ObjectValidation) ExistingContentDigests() iter.Seq[PathDigests] {
 // ValidationAlgorithms returns the registry of digest algoriths
 // the object validation is configured to use. The default value is
 // digest.DefaultRegistry
-func (v *ObjectValidation) ValidationAlgorithms() digest.Registry {
+func (v *ObjectValidation) ValidationAlgorithms() digest.AlgorithmRegistry {
 	return v.algRegistry
 }
 
@@ -296,7 +296,7 @@ func ValidationDigestConcurrency(num int) ObjectValidationOption {
 
 // ValidationAlgorithms sets registry of available digest algorithms for
 // fixity validation.
-func ValidationAlgorithms(reg digest.Registry) ObjectValidationOption {
+func ValidationAlgorithms(reg digest.AlgorithmRegistry) ObjectValidationOption {
 	return func(v *ObjectValidation) {
 		v.algRegistry = reg
 	}

--- a/validation.go
+++ b/validation.go
@@ -175,7 +175,7 @@ func (v *ObjectValidation) AddInventoryDigests(inv ReadInventory) error {
 	allErrors := &multierror.Error{}
 	inv.Manifest().EachPath(func(name string, primaryDigest string) bool {
 		allDigests := inv.GetFixity(primaryDigest)
-		allDigests[primaryAlg] = primaryDigest
+		allDigests[primaryAlg.ID()] = primaryDigest
 		current := v.files[name]
 		if current == nil {
 			v.files[name] = &validationFileInfo{

--- a/validation.go
+++ b/validation.go
@@ -73,7 +73,6 @@ func (v *Validation) WarnErrors() []error {
 // ObjectValidation is used to configure and track results from an object validation process.
 type ObjectValidation struct {
 	Validation
-
 	globals     Config
 	logger      *slog.Logger
 	skipDigests bool

--- a/validation.go
+++ b/validation.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/srerickson/ocfl-go/digest"
 )
 
 // Validation represents multiple fatal errors and warning errors.
@@ -186,7 +187,7 @@ func (v *ObjectValidation) AddInventoryDigests(inv ReadInventory) error {
 			return true
 		}
 		if err := current.expected.Add(allDigests); err != nil {
-			var digestError *DigestError
+			var digestError *digest.DigestError
 			if errors.As(err, &digestError) {
 				digestError.Path = name
 			}
@@ -285,7 +286,7 @@ func ValidationDigestConcurrency(num int) ObjectValidationOption {
 }
 
 type validationFileInfo struct {
-	expected DigestSet
+	expected digest.Set
 	exists   bool
 }
 

--- a/validation.go
+++ b/validation.go
@@ -79,7 +79,7 @@ type ObjectValidation struct {
 	skipDigests bool
 	concurrency int
 	files       map[string]*validationFileInfo
-	algRegister digest.Register
+	algRegister digest.Registry
 }
 
 // NewObjectValidation constructs a new *Validation with the given
@@ -287,9 +287,9 @@ func ValidationDigestConcurrency(num int) ObjectValidationOption {
 }
 
 // ValidateDigestAlgorithms is used to set the
-func ValidateDigestAlgorithms(algs ...digest.Alg) ObjectValidationOption {
+func ValidateDigestAlgorithms(algs ...digest.Algorithm) ObjectValidationOption {
 	return func(v *ObjectValidation) {
-		v.algRegister = digest.NewRegister(algs...)
+		v.algRegister = digest.NewRegistry(algs...)
 	}
 }
 


### PR DESCRIPTION
This PR adds (partial) support for extended digest algorithms:
-  new `digest` package contains additional algorithm definitions
- digest algorithm registry type for accessing available algorithms
- implementations for extensions `0001-digest-algorithms` and `0009-digest-algorithms`
- new extension type for extensions that provide an algorithms registry
- object validation accepts an option for setting the algorithm registry.

The PR doesn't include complete functionality for setting and using the algorithm extensions. 