### PR TITLE
DigestMap cleanup

### DIFF
--- a/inventory.go
+++ b/inventory.go
@@ -152,13 +152,12 @@ func (inv rawInventory) getFixity(dig string) digest.Set {
 	}
 	set := digest.Set{}
 	for fixAlg, fixMap := range inv.Fixity {
-		fixMap.EachPath(func(p, fixDigest string) bool {
+		for p, fixDigest := range fixMap.Paths() {
 			if slices.Contains(paths, p) {
 				set[fixAlg] = fixDigest
-				return false
+				break
 			}
-			return true
-		})
+		}
 	}
 	return set
 }

--- a/object.go
+++ b/object.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"path"
 	"slices"
 	"strings"
@@ -295,7 +296,7 @@ type Commit struct {
 	Spec            Spec      // OCFL specification version for the new object version
 	NewHEAD         int       // enforces new object version number
 	AllowUnchanged  bool
-	ContentPathFunc RemapFunc
+	ContentPathFunc func(oldPaths []string) (newPaths []string)
 
 	Logger *slog.Logger
 }
@@ -352,7 +353,7 @@ func (vfs *ObjectVersionFS) User() *User                       { return vfs.ver.
 
 func (vfs *ObjectVersionFS) Stage() *Stage {
 	return &Stage{
-		State:           vfs.State().Clone(),
+		State:           maps.Clone(vfs.State()),
 		DigestAlgorithm: vfs.inv.DigestAlgorithm(),
 		FixitySource:    vfs.inv,
 		ContentSource:   vfs,

--- a/stage_test.go
+++ b/stage_test.go
@@ -24,7 +24,7 @@ func TestStageFiles(t *testing.T) {
 	be.NilErr(t, err)
 	be.Equal(t, stage.DigestAlgorithm.ID(), `sha256`)
 	for _, n := range fixtureFiles {
-		digest := stage.State.GetDigest(n)
+		digest := stage.State.DigestFor(n)
 		be.Nonzero(t, digest)
 		fsys, path := stage.GetContent(digest)
 		be.Nonzero(t, fsys)
@@ -47,7 +47,7 @@ func TestStageDir(t *testing.T) {
 	be.Equal(t, `sha256`, stage.DigestAlgorithm.ID())
 	be.Equal(t, 3, len(stage.State))
 	expectedPath := "folder1/folder2/sculpture-stone-face-head-888027.jpg"
-	expDigest := stage.State.GetDigest(expectedPath)
+	expDigest := stage.State.DigestFor(expectedPath)
 	be.Nonzero(t, expDigest)
 	resolveFS, resolvePath := stage.GetContent(expDigest)
 	be.Nonzero(t, resolveFS)

--- a/validation.go
+++ b/validation.go
@@ -209,7 +209,7 @@ func (v *ObjectValidation) addInventory(inv Inventory, isRoot bool) error {
 	}
 	primaryAlg := inv.DigestAlgorithm()
 	allErrors := &multierror.Error{}
-	inv.Manifest().EachPath(func(name string, primaryDigest string) bool {
+	for name, primaryDigest := range inv.Manifest().Paths() {
 		allDigests := inv.GetFixity(primaryDigest)
 		allDigests[primaryAlg.ID()] = primaryDigest
 		existing := v.files[name]
@@ -217,11 +217,11 @@ func (v *ObjectValidation) addInventory(inv Inventory, isRoot bool) error {
 			v.files[name] = &validationFileInfo{
 				expectedDigests: allDigests,
 			}
-			return true
+			continue
 		}
 		if existing.expectedDigests == nil {
 			existing.expectedDigests = allDigests
-			return true
+			continue
 		}
 		if err := existing.expectedDigests.Add(allDigests); err != nil {
 			var digestError *digest.DigestError
@@ -230,8 +230,7 @@ func (v *ObjectValidation) addInventory(inv Inventory, isRoot bool) error {
 			}
 			allErrors = multierror.Append(allErrors, err)
 		}
-		return true
-	})
+	}
 	if err := allErrors.ErrorOrNil(); err != nil {
 		return err
 	}


### PR DESCRIPTION
This is mostly cleanup and name changes for methods on `ocfl.DigestMap`. Notably, the `Paths()` method is now an iterator (#91) and validation code is simplified. Deletes more than it adds!