### PR TITLE
s3: open files with HeadObject

### DIFF
--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -112,6 +112,7 @@ type S3API interface {
 
 // OpenFileAPI includes S3 methods needed for OpenFile()
 type OpenFileAPI interface {
+	HeadObject(context.Context, *s3v2.HeadObjectInput, ...func(*s3v2.Options)) (*s3v2.HeadObjectOutput, error)
 	GetObject(context.Context, *s3v2.GetObjectInput, ...func(*s3v2.Options)) (*s3v2.GetObjectOutput, error)
 }
 


### PR DESCRIPTION
This changes the s3 backend's `OpenFile()` behavior slightly: `s3.HeadObject()` is used during open; `s3.GetObject()` isn't called until the first read.