### PR TITLE
Check file types during staging, not walking

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -221,12 +221,6 @@ func fileWalk(ctx context.Context, fsys FS, walkRoot string, subDir string, yiel
 			if !fileWalk(ctx, fsys, walkRoot, entryPath, yield) {
 				return false
 			}
-		case !ValidFileType(e.Type()):
-			return yield(nil, &fs.PathError{
-				Path: entryPath,
-				Err:  ErrFileType,
-				Op:   `readdir`,
-			})
 		default:
 			info, err := e.Info()
 			if err != nil {

--- a/testdata/content-fixture/folder1/folder2/.hidden_folder/hidden_link.txt
+++ b/testdata/content-fixture/folder1/folder2/.hidden_folder/hidden_link.txt
@@ -1,0 +1,1 @@
+hidden_file.txt


### PR DESCRIPTION
This adds `fs.CheckFileTypes()` which is used during `StageFiles()` to check for invalid file types. Invalid file types encountered during  `fs.WalkFiles()` no longer cause an error. Fixes #132 