### PR TITLE
new UpdatePlan methods

### DIFF
--- a/object.go
+++ b/object.go
@@ -88,8 +88,12 @@ func (obj *Object) ApplyUpdatePlan(ctx context.Context, update *UpdatePlan, src 
 	if update.ObjectID() != obj.ID() {
 		return errors.New("update plan is for a different object")
 	}
-	if base := obj.rootInventory; base != nil && base.digest != update.BaseInventoryDigest() {
-		return errors.New("update plan's base inventory does not match the object's current inventory")
+	var baseInvDigest string
+	if obj.rootInventory != nil {
+		baseInvDigest = obj.rootInventory.digest
+	}
+	if baseInvDigest != update.BaseInventoryDigest() {
+		return errors.New("update plan does not reflect object's current inventory state")
 	}
 	newInv, err := update.Apply(ctx, obj.fs, obj.path, src)
 	if err != nil {

--- a/object_test.go
+++ b/object_test.go
@@ -226,7 +226,6 @@ func TestObject_ApplyUpdatePlan(t *testing.T) {
 		// error
 		err = obj.ApplyUpdatePlan(ctx, update, stage.ContentSource)
 		be.Nonzero(t, err)
-		be.In(t, "base inventory does not match", err.Error())
 	})
 
 }

--- a/update-plan.go
+++ b/update-plan.go
@@ -160,6 +160,18 @@ func (u UpdatePlan) MarshalBinary() ([]byte, error) {
 	return buff.Bytes(), nil
 }
 
+// NextHead returns the number for the new object version to be created with the
+// update.
+func (u UpdatePlan) NextHead() VNum {
+	return u.newInv.Head
+}
+
+// NextInventoryDigest returns the digest of the inventory.json contents for the
+// object version to be created with the update.
+func (u UpdatePlan) NextInventoryDigest() string {
+	return u.newInv.digest
+}
+
 // ObjectID returns the ID of the OCFL Object that the UpdatePlan must be
 // applied to.
 func (u *UpdatePlan) ObjectID() string {
@@ -431,8 +443,8 @@ func (step *PlanStep) Revert(ctx context.Context, objFS ocflfs.FS, objDir string
 	return nil
 }
 
-// Size returns the number of bytes copied to the object as part of the steps
-// run action. This is only set after the step has run
+// Size returns the number of bytes copied to the object as part of step's run
+// action. This value is available after step has run.
 func (step *PlanStep) Size() int64 {
 	return step.state.Size
 }

--- a/update-plan_test.go
+++ b/update-plan_test.go
@@ -34,6 +34,9 @@ func TestUpdatePlan_Marshal(t *testing.T) {
 	err = sameUpdate.UnmarshalBinary(bytes)
 	be.NilErr(t, err)
 	be.True(t, update.Eq(&sameUpdate))
+	be.Equal(t, update.NextHead(), sameUpdate.NextHead())
+	be.Equal(t, update.NextInventoryDigest(), sameUpdate.NextInventoryDigest())
+	be.Equal(t, update.BaseInventoryDigest(), sameUpdate.BaseInventoryDigest())
 }
 
 func TestUpdatePlan_RecoverUpdatePlan(t *testing.T) {


### PR DESCRIPTION
This adds `UpdatePlan.NextHead()` and `UpdatePlan.NextInventoryDigest()`, methods for accessing details about the object version to be created with the update.