### PR TITLE
ability to initialize objects with an existing inventory value

### DIFF
--- a/ocflv1.go
+++ b/ocflv1.go
@@ -467,7 +467,7 @@ func (imp ocflV1) ValidateObjectVersion(ctx context.Context, vldr *ObjectValidat
 	vnumStr := vnum.String()
 	fullVerDir := path.Join(vldr.path(), vnumStr) // version directory path relative to FS
 	specStr := string(imp.v1Spec)
-	rootInv := vldr.obj.rootInventory // rootInv is assumed to be valid
+	rootInv := vldr.obj.inventory // rootInv is assumed to be valid
 	vDirEntries, err := ocflfs.ReadDir(ctx, fsys, fullVerDir)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		// can't read version directory for some reason, but not because it
@@ -575,7 +575,7 @@ func (imp ocflV1) ValidateObjectContent(ctx context.Context, v *ObjectValidation
 }
 
 func (imp ocflV1) compareVersionInventory(obj *Object, dirNum VNum, verInv *StoredInventory, vldr *ObjectValidation) {
-	rootInv := obj.rootInventory
+	rootInv := obj.inventory
 	specStr := string(imp.v1Spec)
 	if verInv.Head == rootInv.Head && verInv.Digest() != rootInv.Digest() {
 		err := fmt.Errorf("%s/inventor.json is not the same as the root inventory: digests don't match", dirNum)

--- a/validation.go
+++ b/validation.go
@@ -235,7 +235,8 @@ func (v *ObjectValidation) addInventory(inv *StoredInventory, isRoot bool) error
 		return err
 	}
 	if isRoot {
-		v.obj.rootInventory = inv
+		v.obj.inventory = inv
+		v.obj.inventoryIsRoot = true
 	}
 	return nil
 }


### PR DESCRIPTION
This adds a new option, `ObjectWithInventory()`, which an be used in `NewObject()` to initialize objects using an existing inventory value. In conjunction with an inventory cache, this should help optimize access.  Closes #131.

To help implement inventory caches, I also added binary marshaling on `StoredInventory` for saving and restoring inventories.  (Binary marshaling is needed instead of json marshaling because the latter may not preserve the exact inventory  bytes.)

Another issue is preventing objects from being updated if they are initialized using non-root inventories. When an object is initialized using `ObjectWithInventory`, the given inventory's digest is still validated with the root inventory sidecar file. That provides some assurance that the inventory matches the object's actual root inventory. However, if `ObjectSkipRootSidecarValidation` is also used, this validation is skipped. When both options are used together, object updates are not allowed: a new method `Object.ReadOnly()` returns an error, which is now checked in `Object.ApplyUpdate()`.
