### PR TITLE
fs/local: make Write atomic, preserve target mode, honor ctx

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,4 +35,10 @@ jobs:
               exit 1
             fi
 
+            # The repo builds for windows too (fs/local's atomic Write relies
+            # on os.Rename being MoveFileEx(MOVEFILE_REPLACE_EXISTING) there),
+            # but CI only runs linux. Cross-compile vet is the cheap check
+            # that nothing windows-only has broken.
+            GOOS=windows go vet ./...
+
             go test ./... -count=5 -race

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 This is an implementation of the [Oxford Common File Layout](https://ocfl.io/)
 for [Go](https://go.dev). The module can be used in Go programs to support
 operations on OCFL storage roots and objects. It supports the local file system
-or s3 storage backends. Several complete [example programs](examples) are
+or s3 storage backends. Writes to the local backend replace files in one step:
+content goes to a temporary file that is renamed over the target, so a failed,
+canceled, or interrupted write leaves the previous file intact and never
+exposes a truncated one. Several complete [example programs](examples) are
 included.
 
 > [!WARNING]  

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -47,6 +47,23 @@ type FileWalker interface {
 // WriteFS is a storage backend that supports write and remove operations.
 type WriteFS interface {
 	FS
+	// Write writes the contents of buffer to the file with path name,
+	// replacing any existing file, and returns the number of bytes
+	// written.
+	//
+	// Implementations should replace name in a single step wherever the
+	// backend allows it: name must never be observable holding partially
+	// written contents, and a Write that fails, is canceled, or dies
+	// mid-write must leave the previous contents intact and must not
+	// create a partial file where none existed. The s3 implementation
+	// gets this from object-upload semantics — the object appears at name
+	// only once fully uploaded. The local implementation writes to a
+	// temporary file in the target's own directory and renames it over
+	// name, which is an atomic replace on POSIX and, via
+	// MoveFileEx(MOVEFILE_REPLACE_EXISTING), on Windows.
+	//
+	// An implementation that cannot offer this should say so in its own
+	// Write documentation.
 	Write(ctx context.Context, name string, buffer io.Reader) (int64, error)
 	// Remove the file with path name.
 	//

--- a/fs/internal/imptest/imptest.go
+++ b/fs/internal/imptest/imptest.go
@@ -58,9 +58,10 @@
 // already satisfies is skipped for both — the TODO says which, so the fixing
 // PR knows what it is turning on. Writing the test now and skipping it is the
 // point: the PR that fixes the defect deletes one line, and its diff shows
-// exactly which behavior it makes good on. Three stand at the moment — local
-// Write atomicity (#163), the fileWalk nil-deref (#165), and the s3 Remove
-// above (#166).
+// exactly which behavior it makes good on. Two stand at the moment — the
+// fileWalk nil-deref (#165) and the s3 Remove above (#166); local Write
+// atomicity (#163) was the third until #163 landed and turned its two
+// subtests on.
 //
 // # Import direction
 //

--- a/fs/internal/imptest/writefs.go
+++ b/fs/internal/imptest/writefs.go
@@ -83,11 +83,6 @@ func TestWriteFSWrite(t *testing.T, fsys ocflfs.WriteFS) {
 	})
 
 	t.Run("source error leaves previous content intact", func(t *testing.T) {
-		// TODO(#163): local Write opens the destination with O_TRUNC and
-		// copies into it, so a failing source leaves the target truncated.
-		// The s3 backend already satisfies this; drop the skip when #163
-		// makes local Write atomic and the assertion runs for both.
-		t.Skip("local Write is not atomic; see #163")
 		const name, original = "imptest-write/failed-overwrite.txt", "original content"
 		_, err := fsys.Write(ctx, name, strings.NewReader(original))
 		be.NilErr(t, err)
@@ -103,9 +98,6 @@ func TestWriteFSWrite(t *testing.T, fsys ocflfs.WriteFS) {
 	})
 
 	t.Run("source error on a new file leaves nothing behind", func(t *testing.T) {
-		// TODO(#163): the same non-atomic local Write creates an empty file
-		// at name before the source fails. Already satisfied by s3.
-		t.Skip("local Write is not atomic; see #163")
 		const name = "imptest-write/never-created.txt"
 		_, err := fsys.Write(ctx, name, &failingReader{
 			prefix: []byte("bytes that must not become a file"),

--- a/fs/local/atomic_write_test.go
+++ b/fs/local/atomic_write_test.go
@@ -1,0 +1,511 @@
+package local
+
+// atomic_write_test.go pins the atomic-write contract of FS.Write:
+// write-to-temp-file-in-same-directory + rename. Each test is written to
+// fail against the pre-atomic implementation (which opened the target with
+// O_CREATE|O_TRUNC and copied in place with plain io.Copy):
+//
+//   - a large payload never appears truncated at the final path,
+//   - cancellation or a source error mid-write leaves the final path
+//     unchanged (absent for a new target, previous content for an existing
+//     one) and removes the temp file,
+//   - concurrent readers only ever observe the old or the new complete
+//     content, never a partial file,
+//   - the temp file lives in the target's own directory and is removed on
+//     both success and failure.
+//
+// The file is self-contained (no helpers shared with localfs_test.go) and
+// uses only the public FS API, so it compiles against the old implementation
+// unchanged and fails there for behavioral reasons.
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/carlmjohnson/be"
+)
+
+// atomicTempFiles returns the atomic-write temp files (".<base>.tmp-<random>")
+// currently present in dir. After Write returns — successfully or not — this
+// must be empty: any match is a leaked temp file.
+func atomicTempFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, ".*.tmp-*"))
+	be.NilErr(t, err)
+	return matches
+}
+
+// gateReader hands the writer one chunk, then blocks every subsequent Read
+// until release is closed. first is closed as soon as the first chunk has
+// been handed to the writer, which — because the temp file is created before
+// the copy starts — guarantees the temp file exists once the test observes
+// first. If err is set, it is returned as soon as the reader is released,
+// simulating a source failure mid-write. It deliberately does not implement
+// io.WriterTo, so both io.Copy (old impl) and copyWithContext (new impl)
+// read it chunk by chunk.
+type gateReader struct {
+	data    []byte
+	pos     int
+	first   chan struct{} // closed after the first chunk is served
+	release chan struct{} // subsequent reads block until this closes
+	gated   bool          // whether the release gate has been consumed
+	started bool          // whether first has been closed
+	err     error         // optional error returned once released
+}
+
+func (r *gateReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	if r.pos > 0 && !r.gated {
+		<-r.release
+		r.gated = true
+		if r.err != nil {
+			return 0, r.err
+		}
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	if n > 0 && !r.started {
+		r.started = true
+		close(r.first)
+	}
+	return n, nil
+}
+
+// pacedReader yields its data in small chunks with a fixed pause between
+// reads, so a Write fed from it takes tens of milliseconds. That keeps the
+// old implementation's truncate-then-copy window open long enough for
+// concurrent readers to reliably observe partial states.
+type pacedReader struct {
+	data  []byte
+	pos   int
+	step  int
+	pause time.Duration
+}
+
+func (r *pacedReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	if r.pos > 0 {
+		time.Sleep(r.pause)
+	}
+	end := r.pos + r.step
+	if end > len(r.data) {
+		end = len(r.data)
+	}
+	n := copy(p, r.data[r.pos:end])
+	r.pos += n
+	return n, nil
+}
+
+// patterned returns n bytes of a deterministic, non-repeating pattern so an
+// exact content comparison cannot be fooled by a truncation that happens to
+// land on a repeated character.
+func patterned(n int, seed byte) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = seed + byte(i)*31
+	}
+	return b
+}
+
+func TestFS_WriteAtomic(t *testing.T) {
+	t.Run("large payload is written completely and exactly", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		payload := patterned(8*1024*1024, 0xA0)
+		n, err := fsys.Write(context.Background(), "big.bin", bytes.NewReader(payload))
+		be.NilErr(t, err)
+		be.Equal(t, int64(len(payload)), n)
+
+		data, err := os.ReadFile(filepath.Join(tmpDir, "big.bin"))
+		be.NilErr(t, err)
+		be.True(t, bytes.Equal(payload, data))
+		be.Equal(t, 0, len(atomicTempFiles(t, tmpDir)))
+	})
+
+	t.Run("cancellation mid-write leaves target absent and no temp files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		payload := patterned(1024*1024, 0xB0)
+		r := &gateReader{data: payload, first: make(chan struct{}), release: make(chan struct{})}
+
+		var werr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, werr = fsys.Write(ctx, "test.bin", r)
+		}()
+		<-r.first
+		cancel()
+		close(r.release)
+		wg.Wait()
+
+		// The canceled write must report the cancellation, must not create a
+		// file at the final path (new target), and must remove its temp file.
+		// The old implementation ignores the cancellation mid-copy, completes
+		// the write and returns nil, so this fails there.
+		be.True(t, errors.Is(werr, context.Canceled))
+		if _, statErr := os.Stat(filepath.Join(tmpDir, "test.bin")); !os.IsNotExist(statErr) {
+			t.Fatalf("file appeared at final path despite cancellation: %v", statErr)
+		}
+		be.Equal(t, 0, len(atomicTempFiles(t, tmpDir)))
+	})
+
+	t.Run("cancellation mid-write keeps previous content and no temp files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		oldContent := patterned(256*1024, 0x4F)
+		ctx := context.Background()
+		_, err = fsys.Write(ctx, "test.bin", bytes.NewReader(oldContent))
+		be.NilErr(t, err)
+
+		ctx, cancel := context.WithCancel(ctx)
+		payload := patterned(1024*1024, 0xB1)
+		r := &gateReader{data: payload, first: make(chan struct{}), release: make(chan struct{})}
+
+		var werr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, werr = fsys.Write(ctx, "test.bin", r)
+		}()
+		<-r.first
+		cancel()
+		close(r.release)
+		wg.Wait()
+
+		// Cancellation of an overwrite must leave the previous complete file
+		// in place. The old implementation truncates the target up front, so
+		// it fails here with either a partial file or a committed new write.
+		be.True(t, errors.Is(werr, context.Canceled))
+		data, err := os.ReadFile(filepath.Join(tmpDir, "test.bin"))
+		be.NilErr(t, err)
+		be.True(t, bytes.Equal(oldContent, data))
+		be.Equal(t, 0, len(atomicTempFiles(t, tmpDir)))
+	})
+
+	t.Run("failed overwrite preserves previous content", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		oldContent := patterned(256*1024, 0x4F)
+		ctx := context.Background()
+		_, err = fsys.Write(ctx, "test.bin", bytes.NewReader(oldContent))
+		be.NilErr(t, err)
+
+		errBoom := errors.New("source read boom")
+		payload := patterned(1024*1024, 0xB2)
+		r := &gateReader{data: payload, first: make(chan struct{}), release: make(chan struct{}), err: errBoom}
+
+		var werr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, werr = fsys.Write(ctx, "test.bin", r)
+		}()
+		<-r.first
+		close(r.release)
+		wg.Wait()
+
+		// A failing overwrite must preserve the previous content: the old
+		// implementation truncates first and would leave a partial file.
+		be.True(t, errors.Is(werr, errBoom))
+		data, err := os.ReadFile(filepath.Join(tmpDir, "test.bin"))
+		be.NilErr(t, err)
+		be.True(t, bytes.Equal(oldContent, data))
+		be.Equal(t, 0, len(atomicTempFiles(t, tmpDir)))
+	})
+
+	t.Run("concurrent readers never observe partial content", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+		ctx := context.Background()
+		target := "shared.bin"
+		full := filepath.Join(tmpDir, target)
+
+		oldContent := patterned(256*1024, 0x4F)
+		newContent := patterned(1024*1024, 0xC0)
+		_, err = fsys.Write(ctx, target, bytes.NewReader(oldContent))
+		be.NilErr(t, err)
+
+		// Readers begin sampling, and only then does the writer start, so the
+		// sampling window provably overlaps the (deliberately slow) write.
+		startWrite := make(chan struct{})
+		writeDone := make(chan struct{})
+		var readyWG sync.WaitGroup
+		const readers = 3
+		readyWG.Add(readers)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer close(writeDone)
+			<-startWrite
+			_, _ = fsys.Write(ctx, target, &pacedReader{data: newContent, step: 8 * 1024, pause: 250 * time.Microsecond})
+		}()
+
+		readErrs := make(chan string, readers)
+		var rwg sync.WaitGroup
+		rwg.Add(readers)
+		for range readers {
+			go func() {
+				defer rwg.Done()
+				readyWG.Done()
+				for i := 0; i < 300; i++ {
+					done := false
+					select {
+					case <-writeDone:
+						done = true
+					default:
+					}
+					f, err := os.Open(full)
+					if err != nil {
+						readErrs <- fmt.Sprintf("open failed: %v", err)
+						return
+					}
+					data, err := io.ReadAll(f)
+					f.Close()
+					if err != nil {
+						readErrs <- fmt.Sprintf("read failed: %v", err)
+						return
+					}
+					if !bytes.Equal(data, oldContent) && !bytes.Equal(data, newContent) {
+						readErrs <- fmt.Sprintf("observed partial content (%d bytes)", len(data))
+						return
+					}
+					if done {
+						return
+					}
+				}
+			}()
+		}
+		readyWG.Wait()
+		close(startWrite)
+		rwg.Wait()
+		close(readErrs)
+		for msg := range readErrs {
+			t.Errorf("%s", msg)
+		}
+		wg.Wait()
+
+		final, err := os.ReadFile(full)
+		be.NilErr(t, err)
+		be.True(t, bytes.Equal(newContent, final))
+		be.Equal(t, 0, len(atomicTempFiles(t, tmpDir)))
+	})
+
+	t.Run("temp file appears in target directory during write and is removed on success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		payload := patterned(1024*1024, 0xD0)
+		r := &gateReader{data: payload, first: make(chan struct{}), release: make(chan struct{})}
+
+		var n int64
+		var werr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			n, werr = fsys.Write(context.Background(), "test.bin", r)
+		}()
+		<-r.first
+
+		// The write is blocked mid-copy with bytes already in the temp file.
+		// The temp file must exist, live in the same directory as the target
+		// (so the final rename is atomic on the same filesystem), and be the
+		// only temp file. The old implementation, which copies straight to the
+		// final path, never creates one, so this fails there.
+		temps := atomicTempFiles(t, tmpDir)
+		be.Equal(t, 1, len(temps))
+		be.Equal(t, tmpDir, filepath.Dir(temps[0]))
+		be.True(t, temps[0] != filepath.Join(tmpDir, "test.bin"))
+
+		close(r.release)
+		wg.Wait()
+		be.NilErr(t, werr)
+		be.Equal(t, int64(len(payload)), n)
+
+		data, err := os.ReadFile(filepath.Join(tmpDir, "test.bin"))
+		be.NilErr(t, err)
+		be.True(t, bytes.Equal(payload, data))
+		be.Equal(t, 0, len(atomicTempFiles(t, tmpDir)))
+	})
+
+	t.Run("temp file is removed when the write fails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		errBoom := errors.New("source read boom")
+		payload := patterned(1024*1024, 0xD1)
+		r := &gateReader{data: payload, first: make(chan struct{}), release: make(chan struct{}), err: errBoom}
+
+		var werr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, werr = fsys.Write(context.Background(), "test.bin", r)
+		}()
+		<-r.first
+
+		temps := atomicTempFiles(t, tmpDir)
+		be.Equal(t, 1, len(temps))
+		be.Equal(t, tmpDir, filepath.Dir(temps[0]))
+
+		close(r.release)
+		wg.Wait()
+		be.True(t, errors.Is(werr, errBoom))
+
+		// Failed write on a new target: no file at the final path, and the
+		// temp file that existed mid-write must be gone.
+		if _, statErr := os.Stat(filepath.Join(tmpDir, "test.bin")); !os.IsNotExist(statErr) {
+			t.Fatalf("file appeared at final path despite failure: %v", statErr)
+		}
+		be.Equal(t, 0, len(atomicTempFiles(t, tmpDir)))
+	})
+}
+
+// selfCancelingCtx reports no error on its first Err() call and
+// context.Canceled on every one after it. Write consults ctx once before it
+// touches the filesystem and then once per read of the source, so this puts
+// the cancellation precisely inside the copy without a sleep or a race — the
+// window a real ctx can only be canceled into by timing.
+type selfCancelingCtx struct {
+	context.Context
+	calls atomic.Int64
+}
+
+func (c *selfCancelingCtx) Err() error {
+	if c.calls.Add(1) == 1 {
+		return nil
+	}
+	return context.Canceled
+}
+
+// TestFS_WriteCtxReaderHidesWriterTo pins the reason ctxReader exposes only
+// Read.
+//
+// io.Copy consults io.WriterTo on the source before anything else. Sources
+// like *strings.Reader, *bytes.Reader and *os.File implement it, so a
+// wrapper that forwarded the method would hand io.Copy a fast path straight
+// from the source to the destination file — one that never calls Read and
+// therefore never sees the context. The copy would then run to completion
+// after its caller had given up, and the canceled write would commit.
+func TestFS_WriteCtxReaderHidesWriterTo(t *testing.T) {
+	t.Run("ctxReader does not implement io.WriterTo", func(t *testing.T) {
+		// The source does, which is what makes the wrapper's silence matter.
+		var _ io.WriterTo = strings.NewReader("x")
+		var r io.Reader = ctxReader{ctx: context.Background(), src: strings.NewReader("x")}
+		if _, ok := r.(io.WriterTo); ok {
+			t.Fatal("ctxReader must not expose io.WriterTo: io.Copy would take the fast path and never check the context")
+		}
+	})
+
+	t.Run("io.Copy from a canceled ctxReader over *strings.Reader copies nothing", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		var buf bytes.Buffer
+		n, err := io.Copy(&buf, ctxReader{ctx: ctx, src: strings.NewReader("content that must not be copied")})
+		be.True(t, errors.Is(err, context.Canceled))
+		be.Equal(t, int64(0), n)
+		be.Equal(t, 0, buf.Len())
+	})
+
+	t.Run("cancellation during a *strings.Reader write leaves the target alone", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		ctx := &selfCancelingCtx{Context: context.Background()}
+		// *strings.Reader specifically: this is the source type whose
+		// WriterTo fast path would defeat a naive wrapper.
+		_, werr := fsys.Write(ctx, "test.txt", strings.NewReader(strings.Repeat("payload", 4096)))
+		be.True(t, errors.Is(werr, context.Canceled))
+
+		if _, statErr := os.Stat(filepath.Join(tmpDir, "test.txt")); !os.IsNotExist(statErr) {
+			t.Fatalf("canceled write committed anyway (the WriterTo fast path bypassed the context check): %v", statErr)
+		}
+		be.Equal(t, 0, len(atomicTempFiles(t, tmpDir)))
+	})
+}
+
+// TestFS_WriteFailureReportsZeroBytes pins the count returned alongside a
+// pre-rename failure. Bytes reach the temp file, but the temp file is
+// removed and nothing ever reaches name, so reporting what was copied would
+// describe a file that does not exist.
+func TestFS_WriteFailureReportsZeroBytes(t *testing.T) {
+	tmpDir := t.TempDir()
+	fsys, err := NewFS(tmpDir)
+	be.NilErr(t, err)
+
+	errBoom := errors.New("source read boom")
+	payload := patterned(512*1024, 0xE0)
+	r := &gateReader{data: payload, first: make(chan struct{}), release: make(chan struct{}), err: errBoom}
+
+	var n int64
+	var werr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		n, werr = fsys.Write(context.Background(), "test.bin", r)
+	}()
+	<-r.first
+	close(r.release)
+	wg.Wait()
+
+	be.True(t, errors.Is(werr, errBoom))
+	be.Equal(t, int64(0), n)
+}
+
+// BenchmarkWriteMany puts the per-file cost of the durability work — the
+// temp file, its fsync, the rename and the containing directory's fsync — on
+// the record, so any future argument for an opt-out knob starts from a
+// number rather than an intuition.
+func BenchmarkWriteMany(b *testing.B) {
+	for _, size := range []int{1024, 64 * 1024, 1024 * 1024} {
+		b.Run(fmt.Sprintf("%dB", size), func(b *testing.B) {
+			tmpDir := b.TempDir()
+			fsys, err := NewFS(tmpDir)
+			if err != nil {
+				b.Fatal(err)
+			}
+			ctx := context.Background()
+			payload := patterned(size, 0x11)
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				if _, err := fsys.Write(ctx, fmt.Sprintf("bench/file-%d.bin", i), bytes.NewReader(payload)); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/fs/local/localfs.go
+++ b/fs/local/localfs.go
@@ -6,15 +6,22 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"unicode/utf8"
 
+	"github.com/rogpeppe/go-internal/robustio"
 	ocflfs "github.com/srerickson/ocfl-go/fs"
 )
 
 const (
-	dirPerm  = 0755
-	filePerm = 0644
+	dirPerm = 0755
+	// tempPerm is the creation mode for the temp file behind Write's
+	// atomic-write sequence. It is subject to the process umask, so a new
+	// file lands at 0666 &^ umask (typically 0644), matching os.Create. An
+	// existing target's mode is chmod'd onto the temp file instead.
+	tempPerm = 0666
 )
 
 type FS struct {
@@ -41,6 +48,35 @@ func (fsys *FS) Root() string {
 	return fsys.path
 }
 
+// Write writes the contents of src to the file named name, creating any
+// missing parent directories, and returns the number of bytes written.
+//
+// The replacement happens in one step: src is copied to a unique temporary
+// file (".<base>.tmp-<random>") in the target's own directory, synced, and
+// then renamed over name once the copy is complete — an atomic replace on
+// POSIX and, via MoveFileEx(MOVEFILE_REPLACE_EXISTING), on Windows. A reader
+// of name therefore observes either the previous file or the new file in
+// full, never a truncated or partially written one. A failed copy, a canceled
+// context or a crash before the rename leaves the previous contents
+// untouched, and creates nothing at name when it did not exist. Every path
+// before the rename removes the temporary file (best-effort), so failed
+// writes do not leak one; a crash can leave one behind, where it is visible
+// as an ordinary dot-file.
+//
+// If name already exists as a regular file, its permissions are carried onto
+// the replacement exactly. Otherwise the new file is created with mode 0666
+// subject to the process umask, matching os.Create. A symlink at name is
+// replaced by the link entry being renamed over: the referent is not written
+// through and neither its mode nor the link's own 0777 is copied onto the new
+// regular file.
+//
+// ctx is honored between reads from src: a canceled or expired context aborts
+// the copy and is reported as itself, so callers can match context.Canceled
+// and context.DeadlineExceeded. Cancellation is not observed during the final
+// rename, which is one syscall from committing an already-complete copy.
+//
+// On any failure before the rename the returned count is 0: no bytes reached
+// name.
 func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, error) {
 	fullPath, err := fsys.osPath(name)
 	if err != nil {
@@ -76,7 +112,34 @@ func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, e
 			Err:  err,
 		}
 	}
-	dst, err := os.OpenFile(fullPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, filePerm)
+	// Preserve the target's permissions when it already exists as a regular
+	// file: the temp file is chmod'd to the exact mode, and chmod is not
+	// umask-masked, so the mode is copied rather than approximated. The
+	// chmod happens after the (umask-affected) create, so it always wins.
+	//
+	// The target is examined with Lstat and only a regular file contributes
+	// a mode. For a symlink neither mode on hand describes the file being
+	// created: Stat would give the referent's, which belongs to a file that
+	// is not being written, and Lstat gives the link's own, which is 0777 on
+	// POSIX and would publish a world-writable regular file. IsRegular
+	// rejects both, along with directories and devices, in one condition.
+	//
+	// havePerm, rather than a preserveMode != 0 sentinel, distinguishes "no
+	// mode to preserve" from a target whose mode legitimately is 0000. Lstat
+	// errors are tolerated: a missing target is simply a new file at the
+	// default temp mode.
+	var (
+		preserveMode fs.FileMode
+		havePerm     bool
+	)
+	if info, err := os.Lstat(fullPath); err == nil && info.Mode().IsRegular() {
+		preserveMode, havePerm = info.Mode().Perm(), true
+	}
+	// The temp file goes in the target's own directory so the final rename
+	// is within one filesystem, where it is an atomic replace. O_EXCL at
+	// creation means it can never clobber an existing file, even if another
+	// writer races in the same directory.
+	tmpPath, tmp, err := createTempFile(parent, fullPath)
 	if err != nil {
 		return 0, &fs.PathError{
 			Op:   "write",
@@ -84,23 +147,158 @@ func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, e
 			Err:  err,
 		}
 	}
-	n, err := io.Copy(dst, src)
+	// Until the rename commits, every return path closes and removes the
+	// temp file (best-effort), so a failed or canceled write leaves no litter.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tmp.Close()        // no-op if already closed
+			_ = os.Remove(tmpPath) // no-op if already renamed away
+		}
+	}()
+	if havePerm {
+		if err := tmp.Chmod(preserveMode); err != nil {
+			return 0, &fs.PathError{
+				Op:   "write",
+				Path: name,
+				Err:  err,
+			}
+		}
+	}
+	n, err := io.Copy(tmp, ctxReader{ctx: ctx, src: src})
 	if err != nil {
-		dst.Close()
-		return n, &fs.PathError{
+		// A copy that stopped because the context ended reports the context
+		// error, not whatever the reader or writer said on the way out, so
+		// callers can match context.Canceled / context.DeadlineExceeded.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		}
+		return 0, &fs.PathError{
 			Op:   "write",
 			Path: name,
 			Err:  err,
 		}
 	}
-	if err := dst.Close(); err != nil {
-		return n, &fs.PathError{
+	// Sync before the rename makes the file's contents durable ahead of the
+	// name that publishes them: a crash cannot leave name pointing at a
+	// zero-length or partially flushed file.
+	if err := tmp.Sync(); err != nil {
+		return 0, &fs.PathError{
 			Op:   "write",
 			Path: name,
 			Err:  err,
 		}
+	}
+	// Close must precede the rename: Windows cannot move a file that is
+	// still open.
+	if err := tmp.Close(); err != nil {
+		return 0, &fs.PathError{
+			Op:   "write",
+			Path: name,
+			Err:  err,
+		}
+	}
+	// The atomic swap. robustio.Rename is os.Rename plus a bounded retry
+	// (~2s, randomized backoff) on the transient Windows errors a virus
+	// scanner or the search indexer causes by holding a handle on the
+	// just-closed temp file: ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION,
+	// ERROR_FILE_NOT_FOUND. On darwin it retries ENOENT; on every other
+	// platform it is a plain call through to os.Rename.
+	//
+	// os.Rename is the right primitive on Windows too, contrary to a common
+	// belief that it cannot replace an existing file there: since Go 1.16 it
+	// is MoveFileEx(MOVEFILE_REPLACE_EXISTING) with fixLongPath applied, an
+	// atomic replace that also handles paths past MAX_PATH — which long OCFL
+	// content paths reach. This module requires Go 1.25 (see go.mod), well
+	// past that.
+	//
+	// The retry sleeps without consulting ctx, so a canceled write can block
+	// here for up to ~2s. That is deliberate: the copy is already complete
+	// and the write is one syscall from committing, so finishing beats
+	// abandoning it.
+	if err := robustio.Rename(tmpPath, fullPath); err != nil {
+		return 0, &fs.PathError{
+			Op:   "write",
+			Path: name,
+			Err:  err,
+		}
+	}
+	committed = true
+	// Best-effort fsync of the containing directory persists the rename
+	// itself across a crash — without it a committed inventory can survive
+	// as content while its name does not. Failures are ignored: the write
+	// has already succeeded, and not every filesystem supports fsync on a
+	// directory.
+	if dir, err := os.Open(parent); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
 	}
 	return n, nil
+}
+
+// ctxReader makes a copy from src cancellable by checking ctx before each
+// read.
+//
+// It deliberately exposes only Read. Sources like *strings.Reader,
+// *bytes.Reader and *os.File implement io.WriterTo, which io.Copy consults
+// before anything else; a wrapper that forwarded it would hand the copy a
+// fast path that never calls Read and so never sees the context.
+type ctxReader struct {
+	ctx context.Context
+	src io.Reader
+}
+
+func (r ctxReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.src.Read(p)
+}
+
+// tempFileName returns the name of a temporary file for target, of the form
+// ".<base>.tmp-<random>". The leading dot keeps it out of ordinary listings
+// and the random suffix (enforced with O_EXCL at creation) keeps concurrent
+// writers from colliding.
+//
+// base is truncated as needed to keep the whole name within NAME_MAX (255
+// bytes), which long OCFL content names reach. The truncation backs off to a
+// UTF-8 rune boundary: slicing raw bytes at the limit can split a multibyte
+// rune, producing an invalid name that strict filesystems reject with a
+// confusing error.
+func tempFileName(target string) string {
+	base := filepath.Base(target)
+	const reserved = len(".") + len(".tmp-") + 16 // leading dot, suffix, hex random
+	if max := 255 - reserved; len(base) > max {
+		// Walk back from the byte limit to the nearest byte that starts a
+		// rune, so the slice never ends mid-sequence. base[max] is in range
+		// here (len(base) > max), and the cut > 0 guard stops the scan at
+		// the front of the string, so base[:cut] is valid UTF-8 for any
+		// valid UTF-8 input.
+		cut := max
+		for cut > 0 && !utf8.RuneStart(base[cut]) {
+			cut--
+		}
+		base = base[:cut]
+	}
+	return "." + base + ".tmp-" + fmt.Sprintf("%016x", rand.Uint64())
+}
+
+// createTempFile creates a new file in dir named after target with
+// O_CREATE|O_EXCL|O_WRONLY, so it can never clobber an existing file. A name
+// collision (practically impossible) is retried with a fresh random suffix.
+// The file is created at tempPerm, subject to the process umask.
+func createTempFile(dir, target string) (string, *os.File, error) {
+	for range 10 {
+		path := filepath.Join(dir, tempFileName(target))
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, tempPerm)
+		if err == nil {
+			return path, f, nil
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return "", nil, err
+		}
+	}
+	return "", nil, errors.New("unable to create a unique temp file")
 }
 
 func (fsys *FS) Remove(ctx context.Context, name string) error {

--- a/fs/local/localfs_symlink_test.go
+++ b/fs/local/localfs_symlink_test.go
@@ -1,0 +1,165 @@
+//go:build !windows
+
+package local
+
+// localfs_symlink_test.go pins mode handling in FS.Write when the target is a
+// symlink. The atomic write (temp file + rename) replaces the target entry, so
+// the question is which mode the replacement regular file gets.
+//
+// Neither mode available at the target is the right one to copy. os.Stat would
+// follow the link and stamp the referent's permissions onto a file that is not
+// the referent; the link's own mode (0777 on POSIX) would publish a
+// world-writable regular file. Write therefore only preserves a mode when
+// Lstat reports a regular file, so a symlinked target is written as a new
+// file at the default temp mode. These tests pin that, and pin the POSIX
+// rename behavior the scenario relies on: renaming a symlink over an existing
+// regular file leaves a symlink at the destination.
+//
+// The file is POSIX-only (build tag !windows): Windows has no guaranteed,
+// unprivileged symlink creation.
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/carlmjohnson/be"
+)
+
+// TestFS_Write_SymlinkTargetGetsDefaultMode walks the full scenario: create a
+// symlink source, rename it over an existing regular file, assert the
+// destination is still a symlink, then write through that symlinked target and
+// assert the replacement regular file gets the default new-file mode — not the
+// symlink's 0777 and not the referent's 0600.
+func TestFS_Write_SymlinkTargetGetsDefaultMode(t *testing.T) {
+	root := t.TempDir()
+	fsys, err := NewFS(root)
+	be.NilErr(t, err)
+
+	// The mode a brand-new file gets in this directory, measured rather than
+	// assumed: tempPerm is masked by the process umask, which the test does
+	// not control.
+	_, err = fsys.Write(context.Background(), "probe", strings.NewReader("probe"))
+	be.NilErr(t, err)
+	probeInfo, err := os.Lstat(filepath.Join(root, "probe"))
+	be.NilErr(t, err)
+	defaultPerm := probeInfo.Mode().Perm()
+
+	// Referent with a mode that differs from both the symlink's own mode and
+	// the default, so a leak from either direction is visible.
+	referent := filepath.Join(root, "referent")
+	be.NilErr(t, os.WriteFile(referent, []byte("referent data"), 0o600))
+
+	// A symlink source...
+	link := filepath.Join(root, "src-link")
+	be.NilErr(t, os.Symlink(referent, link))
+	linkInfo, err := os.Lstat(link)
+	be.NilErr(t, err)
+	be.True(t, linkInfo.Mode()&fs.ModeSymlink != 0)
+
+	// ...renamed over an existing regular file. POSIX rename moves the link
+	// entry itself: the destination is still a symlink with the link's own
+	// mode, not the replaced regular file's mode.
+	dst := filepath.Join(root, "dst")
+	be.NilErr(t, os.WriteFile(dst, []byte("old contents"), 0o644))
+	be.NilErr(t, os.Rename(link, dst))
+
+	dstInfo, err := os.Lstat(dst)
+	be.NilErr(t, err)
+	if dstInfo.Mode()&fs.ModeSymlink == 0 {
+		t.Fatalf("renaming a symlink over an existing regular file must leave a symlink at the destination; got mode %v", dstInfo.Mode())
+	}
+	if resolved, rerr := os.Readlink(dst); rerr != nil {
+		t.Fatalf("readlink dst: %v", rerr)
+	} else if resolved != referent {
+		t.Fatalf("dst points at %q, want %q", resolved, referent)
+	}
+
+	// Write through the symlinked target. The atomic rename replaces the link
+	// entry with the temp file, and no mode is preserved from the link.
+	if _, err := fsys.Write(context.Background(), "dst", strings.NewReader("new contents")); err != nil {
+		t.Fatalf("write over symlinked target: %v", err)
+	}
+
+	data, err := os.ReadFile(dst)
+	be.NilErr(t, err)
+	be.Equal(t, "new contents", string(data))
+
+	after, err := os.Lstat(dst)
+	be.NilErr(t, err)
+	if after.Mode()&fs.ModeSymlink != 0 {
+		t.Fatalf("rename replace must leave the regular temp file at dst, not the link")
+	}
+	if after.Mode().Perm() != defaultPerm {
+		t.Fatalf("replacement mode = %v, want the default new-file mode %v", after.Mode().Perm(), defaultPerm)
+	}
+	// Spelled out separately from the equality above: these are the two
+	// specific leaks the Lstat-plus-skip logic exists to prevent, and a
+	// change to defaultPerm must not quietly make either one acceptable.
+	if after.Mode().Perm() == linkInfo.Mode().Perm() {
+		t.Fatalf("symlink's own mode leaked onto the replacement: %v (world-writable on POSIX)", after.Mode().Perm())
+	}
+	if after.Mode().Perm() == 0o600 {
+		t.Fatalf("referent mode leaked onto the replacement: %v", after.Mode().Perm())
+	}
+
+	// The referent itself is untouched: the rename replaced the link entry,
+	// and the link was never followed.
+	refData, err := os.ReadFile(referent)
+	be.NilErr(t, err)
+	be.Equal(t, "referent data", string(refData))
+	refInfo, err := os.Stat(referent)
+	be.NilErr(t, err)
+	be.Equal(t, fs.FileMode(0o600), refInfo.Mode().Perm())
+}
+
+// TestFS_Write_PreservesModeZero pins the one mode a "preserveMode != 0"
+// sentinel cannot represent: an existing target with no permission bits set
+// must keep 0000 rather than being silently widened to the default temp mode.
+func TestFS_Write_PreservesModeZero(t *testing.T) {
+	root := t.TempDir()
+	fsys, err := NewFS(root)
+	be.NilErr(t, err)
+	ctx := context.Background()
+
+	_, err = fsys.Write(ctx, "locked", strings.NewReader("first"))
+	be.NilErr(t, err)
+	target := filepath.Join(root, "locked")
+	be.NilErr(t, os.Chmod(target, 0o000))
+
+	// Writing goes through the temp file, so the unreadable/unwritable target
+	// is never opened directly; only the rename touches it.
+	_, err = fsys.Write(ctx, "locked", strings.NewReader("second"))
+	be.NilErr(t, err)
+
+	info, err := os.Lstat(target)
+	be.NilErr(t, err)
+	if info.Mode().Perm() != 0 {
+		t.Fatalf("mode 0000 not preserved: got %v", info.Mode().Perm())
+	}
+
+	// Content still landed, checked after restoring read access.
+	be.NilErr(t, os.Chmod(target, 0o600))
+	data, err := os.ReadFile(target)
+	be.NilErr(t, err)
+	be.Equal(t, "second", string(data))
+}
+
+// TestFS_Write_ToleratesLstatError pins the graceful error handling of the
+// Lstat in Write's mode-preservation step: when the target does not exist
+// (the common case), the write must proceed as a new file instead of
+// failing on the stat itself.
+func TestFS_Write_ToleratesLstatError(t *testing.T) {
+	root := t.TempDir()
+	fsys, err := NewFS(root)
+	be.NilErr(t, err)
+
+	if _, err := fsys.Write(context.Background(), "brand-new.bin", strings.NewReader("x")); err != nil {
+		t.Fatalf("write to missing target: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "brand-new.bin"))
+	be.NilErr(t, err)
+	be.Equal(t, "x", string(data))
+}

--- a/fs/local/localfs_test.go
+++ b/fs/local/localfs_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/carlmjohnson/be"
 )
@@ -109,15 +110,37 @@ func TestFS_Write(t *testing.T) {
 		fsys, err := NewFS(tmpDir)
 		be.NilErr(t, err)
 
+		// Canceled before Write: Write must return a *fs.PathError wrapping
+		// context.Canceled without touching the filesystem.
 		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel before write
+		cancel()
 
 		_, err = fsys.Write(ctx, "test.txt", strings.NewReader("content"))
-		be.True(t, err != nil)
+		be.True(t, errors.Is(err, context.Canceled))
 
 		var pathErr *fs.PathError
 		be.True(t, errors.As(err, &pathErr))
 		be.Equal(t, "write", pathErr.Op)
+		be.Equal(t, "test.txt", pathErr.Path)
+	})
+
+	t.Run("respects deadline exceeded", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		// An expired deadline surfaces as context.DeadlineExceeded itself,
+		// not as some read error it happened to cause downstream.
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+
+		_, err = fsys.Write(ctx, "test.txt", strings.NewReader("content"))
+		be.True(t, errors.Is(err, context.DeadlineExceeded))
+
+		var pathErr *fs.PathError
+		be.True(t, errors.As(err, &pathErr))
+		be.Equal(t, "write", pathErr.Op)
+		be.Equal(t, "test.txt", pathErr.Path)
 	})
 
 	t.Run("rejects invalid path", func(t *testing.T) {
@@ -143,7 +166,7 @@ func TestFS_Write(t *testing.T) {
 		}
 	})
 
-	t.Run("sets correct file permissions", func(t *testing.T) {
+	t.Run("sets permissions per umask for new files", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		fsys, err := NewFS(tmpDir)
 		be.NilErr(t, err)
@@ -152,10 +175,41 @@ func TestFS_Write(t *testing.T) {
 		_, err = fsys.Write(ctx, "test.txt", strings.NewReader("content"))
 		be.NilErr(t, err)
 
-		// Check file permissions
+		// The contract for a new file is 0666 subject to the process umask,
+		// matching os.Create. The reference file measures the umask instead
+		// of assuming one: a hardcoded 0644 would only be right under 022.
+		ref := filepath.Join(tmpDir, "ref.txt")
+		be.NilErr(t, os.WriteFile(ref, []byte("x"), 0666))
+		refInfo, err := os.Stat(ref)
+		be.NilErr(t, err)
+
 		info, err := os.Stat(filepath.Join(tmpDir, "test.txt"))
 		be.NilErr(t, err)
-		be.Equal(t, fs.FileMode(0644), info.Mode().Perm())
+		be.Equal(t, refInfo.Mode().Perm(), info.Mode().Perm())
+		be.True(t, info.Mode().Perm()&0600 == 0600)
+	})
+
+	t.Run("preserves permissions of existing file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		ctx := context.Background()
+		_, err = fsys.Write(ctx, "test.txt", strings.NewReader("first"))
+		be.NilErr(t, err)
+		be.NilErr(t, os.Chmod(filepath.Join(tmpDir, "test.txt"), 0600))
+
+		// Overwriting keeps the target's mode rather than resetting it to
+		// the umask-derived default: a private file stays private.
+		_, err = fsys.Write(ctx, "test.txt", strings.NewReader("second"))
+		be.NilErr(t, err)
+
+		data, err := os.ReadFile(filepath.Join(tmpDir, "test.txt"))
+		be.NilErr(t, err)
+		be.Equal(t, "second", string(data))
+		info, err := os.Stat(filepath.Join(tmpDir, "test.txt"))
+		be.NilErr(t, err)
+		be.Equal(t, fs.FileMode(0600), info.Mode().Perm())
 	})
 }
 

--- a/fs/local/tempname_test.go
+++ b/fs/local/tempname_test.go
@@ -1,0 +1,107 @@
+package local
+
+// tempname_test.go pins the UTF-8 safety contract of tempFileName: the temp
+// name it returns must always fit NAME_MAX (255 bytes), must stay valid
+// UTF-8 even when the target's base name is a long multibyte string that a
+// raw byte slice would split mid-rune, and must keep the "<truncated base>"
+// prefix correlation with the target so a temp file can be matched back to
+// the file it belongs to.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/carlmjohnson/be"
+)
+
+// dotLen and suffixLen are the fixed parts of a tempFileName result that
+// wrap the (possibly truncated) base: the leading dot, the ".tmp-"
+// separator, and the 16 hex random digits.
+const (
+	dotLen    = len(".")          // leading dot
+	suffixLen = len(".tmp-") + 16 // ".tmp-" separator plus hex random
+)
+
+// basePortion extracts the truncated base embedded in a tempFileName result.
+func basePortion(temp string) string {
+	return temp[dotLen : len(temp)-suffixLen]
+}
+
+func TestTempFileNameUTF8(t *testing.T) {
+	t.Run("short name is unchanged", func(t *testing.T) {
+		temp := tempFileName("plain.bin")
+		be.True(t, strings.HasPrefix(temp, ".plain.bin.tmp-"))
+		be.Equal(t, dotLen+len("plain.bin")+suffixLen, len(temp))
+		be.True(t, len(temp) <= 255)
+		be.True(t, utf8.ValidString(temp))
+	})
+
+	t.Run("multibyte name under limit is not truncated", func(t *testing.T) {
+		base := strings.Repeat("é", 100) // 200 bytes, under the 233-byte budget
+		temp := tempFileName(base)
+		be.True(t, strings.HasPrefix(temp, "."+base+".tmp-"))
+		be.Equal(t, dotLen+len(base)+suffixLen, len(temp))
+		be.True(t, utf8.ValidString(temp))
+		createTempFileOnDisk(t, temp)
+	})
+
+	t.Run("long ASCII name truncates exactly at budget", func(t *testing.T) {
+		base := strings.Repeat("a", 300)
+		temp := tempFileName(base)
+		trunc := basePortion(temp)
+		be.Equal(t, 233, len(trunc))
+		be.True(t, strings.HasPrefix(base, trunc))
+		be.Equal(t, 255, len(temp))
+		be.True(t, utf8.ValidString(temp))
+		createTempFileOnDisk(t, temp)
+	})
+
+	t.Run("long multibyte name truncates on a rune boundary", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			rune  string
+			count int
+		}{
+			{"latin-1 accent e", "é", 128}, // 256 bytes, 2 bytes/rune
+			{"emoji", "😀", 64},             // 256 bytes, 4 bytes/rune
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				base := strings.Repeat(tc.rune, tc.count)
+				t.Logf("base byte length: %d (>255 required)", len(base))
+				be.True(t, len(base) > 255)
+				temp := tempFileName(base)
+
+				// The full temp name must fit NAME_MAX and stay valid UTF-8:
+				// no mid-rune truncation anywhere in the name.
+				be.True(t, len(temp) <= 255)
+				be.True(t, utf8.ValidString(temp))
+
+				// Prefix correlation: the truncated base embedded in the temp
+				// name is a prefix of the original base, and the truncation
+				// only ever shortened it (never to zero for these sizes).
+				trunc := basePortion(temp)
+				be.True(t, strings.HasPrefix(base, trunc))
+				be.True(t, len(trunc) > 0)
+				be.True(t, len(trunc) <= 233)
+
+				// The temp name must actually be creatable on the filesystem.
+				createTempFileOnDisk(t, temp)
+			})
+		}
+	})
+}
+
+// createTempFileOnDisk verifies that name can be created with O_EXCL in a
+// fresh directory on the local filesystem, which is exactly what
+// createTempFile does with tempFileName's result and what strict filesystems
+// reject when a name is invalid UTF-8 or exceeds NAME_MAX.
+func createTempFileOnDisk(t *testing.T, name string) {
+	t.Helper()
+	dir := t.TempDir()
+	f, err := os.OpenFile(filepath.Join(dir, name), os.O_CREATE|os.O_EXCL|os.O_WRONLY, tempPerm)
+	be.NilErr(t, err)
+	be.NilErr(t, f.Close())
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/smithy-go v1.27.3
 	github.com/carlmjohnson/be v0.23.2
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/rogpeppe/go-internal v1.16.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sync v0.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/rogpeppe/go-internal v1.16.0 h1:O9DK+vNMDVGLr2BeZqmpLeMjiMNkuXfcqntWbZV6S5g=
+github.com/rogpeppe/go-internal v1.16.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=


### PR DESCRIPTION
Write opened the destination with O_CREATE|O_TRUNC and copied into it at a
hardcoded 0644. Three defects followed: a failed or canceled copy left the
target truncated or partial with the previous complete file gone; overwriting
a 0600 file silently published it at 0644; and io.Copy never consulted ctx, so
a canceled write kept running.

Write now copies to a unique temp file (".<base>.tmp-<random>",
O_CREATE|O_EXCL|O_WRONLY) in the target's own directory, syncs it, closes it,
and renames it over the target. A reader of the target sees the old file or
the new file in full, never a partial one; every path before the rename
removes the temp file, so failures leave no litter. The containing directory
is fsynced best-effort afterwards so the rename itself survives a crash.

The target's mode is carried onto the replacement with chmod (not umask-
masked, so the mode is copied exactly), but only when Lstat reports a regular
file: for a symlink neither mode on hand describes the file being created —
the referent's belongs to a file that is not being written, and the link's own
is 0777 on POSIX, which would publish a world-writable file. IsRegular rejects
both, plus directories and devices. An explicit havePerm bool, rather than a
preserveMode != 0 sentinel, keeps a target legitimately at 0000 from being
widened to the default. A new file gets 0666 subject to umask, matching
os.Create, in place of the hardcoded 0644.

The copy runs through ctxReader, which checks ctx before each read and
deliberately exposes only Read: *strings.Reader, *bytes.Reader and *os.File
implement io.WriterTo, which io.Copy consults first, so forwarding it would
hand the copy a fast path that never checks the context. A copy that stops
because the context ended reports the context error, so callers can match
context.Canceled and context.DeadlineExceeded.

The rename goes through robustio.Rename rather than a hand-written Windows
helper. os.Rename on Windows has been MoveFileEx(MOVEFILE_REPLACE_EXISTING)
with fixLongPath applied since Go 1.16, so a MoveFileEx helper would only
duplicate it minus long-path handling and degrade to a non-atomic
Remove+Rename fallback. The real Windows hazard is a scanner or indexer
holding a transient handle on the just-closed temp file; robustio retries
those errors with bounded backoff and keeps the atomic replace. On Linux it is
a plain passthrough to os.Rename. Cost is one go.mod line and no transitive
modules, and golang.org/x/sys stays indirect.

The temp name is capped at NAME_MAX with the cut backed off to a UTF-8 rune
boundary, since long multibyte OCFL content names would otherwise produce an
invalid name that strict filesystems reject.

Any failure before the rename now returns 0 bytes written: nothing reached the
target, so reporting the bytes that reached the temp file would describe a
file that does not exist.

Closes item 1 of #164 as a side effect: Write never opens the target path, so
a symlink at name has its link entry replaced rather than being written
through to its referent.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0174A5w1tx7rA1BRUgeLpfb7