### PR TITLE
fs/local: rebuild FS on os.Root so names cannot escape the root

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,9 +36,9 @@ jobs:
             fi
 
             # The repo builds for windows too (fs/local's atomic Write relies
-            # on os.Rename being MoveFileEx(MOVEFILE_REPLACE_EXISTING) there),
-            # but CI only runs linux. Cross-compile vet is the cheap check
-            # that nothing windows-only has broken.
+            # on os.Root.Rename being a replacing rename there), but CI only
+            # runs linux. Cross-compile vet is the cheap check that nothing
+            # windows-only has broken.
             GOOS=windows go vet ./...
 
             go test ./... -count=5 -race

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -59,8 +59,7 @@ type WriteFS interface {
 	// gets this from object-upload semantics — the object appears at name
 	// only once fully uploaded. The local implementation writes to a
 	// temporary file in the target's own directory and renames it over
-	// name, which is an atomic replace on POSIX and, via
-	// MoveFileEx(MOVEFILE_REPLACE_EXISTING), on Windows.
+	// name, which is an atomic replace on POSIX and on Windows alike.
 	//
 	// An implementation that cannot offer this should say so in its own
 	// Write documentation.

--- a/fs/local/localfs.go
+++ b/fs/local/localfs.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"iter"
 	"math/rand/v2"
 	"os"
+	"path"
 	"path/filepath"
+	"slices"
+	"strings"
 	"unicode/utf8"
 
-	"github.com/rogpeppe/go-internal/robustio"
 	ocflfs "github.com/srerickson/ocfl-go/fs"
 )
 
@@ -24,28 +27,147 @@ const (
 	tempPerm = 0666
 )
 
+// FS is a storage backend rooted in a local directory. Every operation goes
+// through a single [os.Root] opened for that directory, so a name can never
+// resolve to a file outside it: os.Root walks a name component by component
+// with the openat family, refusing to follow a symlink whose target leaves the
+// root. That holds for reads as well as writes — the difference from
+// [os.DirFS], whose documentation is explicit that it does follow symlinks out
+// of the directory it was given.
 type FS struct {
-	ocflfs.DirEntriesFS
-	// path is os-specific path to a directory
+	// path is the os-specific path to the root directory. It is kept for
+	// Root() and is never used to build a path handed to the OS.
 	path string
+	// root scopes every operation to path. All file access goes through it.
+	root *os.Root
 }
 
 var _ ocflfs.WriteFS = (*FS)(nil)
 var _ ocflfs.DirEntriesFS = (*FS)(nil)
 
+// NewFS returns an FS for the directory at path, which must exist and be a
+// directory: the [os.Root] opened here holds a descriptor on it, so a missing
+// or non-directory path fails here rather than at the first read or write.
+//
+// The returned FS owns that descriptor. Callers that create many short-lived
+// FS values should [FS.Close] them; the runtime finalizer os.Root installs
+// reclaims a forgotten one at GC, exactly as it does for an [os.File].
 func NewFS(path string) (*FS, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("new backend: %w", err)
 	}
-	return &FS{
-		path:         abs,
-		DirEntriesFS: ocflfs.NewWrapFS(os.DirFS(abs)),
-	}, nil
+	root, err := os.OpenRoot(abs)
+	if err != nil {
+		return nil, fmt.Errorf("new backend: %w", err)
+	}
+	return &FS{path: abs, root: root}, nil
+}
+
+// MustNewFS returns a new FS for path. It panics if the FS cannot be created
+// -- most usefully in tests, where the path is a t.TempDir().
+func MustNewFS(path string) *FS {
+	fsys, err := NewFS(path)
+	if err != nil {
+		panic(err)
+	}
+	return fsys
+}
+
+// Close releases the descriptor held on the root directory. Operations on a
+// closed FS fail; Close is safe to call more than once.
+func (fsys *FS) Close() error {
+	return fsys.root.Close()
 }
 
 func (fsys *FS) Root() string {
 	return fsys.path
+}
+
+// OpenFile opens the named file for reading. name is resolved inside the
+// storage root: a symlink pointing out of the root is an error rather than a
+// door out of it.
+func (fsys *FS) OpenFile(ctx context.Context, name string) (fs.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, &fs.PathError{
+			Op:   "openfile",
+			Path: name,
+			Err:  err,
+		}
+	}
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{
+			Op:   "openfile",
+			Path: name,
+			Err:  fs.ErrInvalid,
+		}
+	}
+	f, err := fsys.root.Open(name)
+	if err != nil {
+		// Root.Open already reports Path as the name it was given, relative
+		// to the root, so nothing needs rewriting to keep the storage root
+		// out of the error. Only Op differs ("openat"), which is normalized
+		// here to the method's own name.
+		var pathErr *fs.PathError
+		if errors.As(err, &pathErr) {
+			pathErr.Op = "openfile"
+		}
+		return nil, err
+	}
+	return f, nil
+}
+
+// DirEntries implements [ocflfs.DirEntriesFS], yielding the entries in the
+// directory named name in sorted order.
+func (fsys *FS) DirEntries(ctx context.Context, name string) iter.Seq2[fs.DirEntry, error] {
+	return func(yield func(fs.DirEntry, error) bool) {
+		if !fs.ValidPath(name) {
+			yield(nil, &fs.PathError{
+				Op:   "readdir",
+				Path: name,
+				Err:  fs.ErrInvalid,
+			})
+			return
+		}
+		dir, err := fsys.root.Open(name)
+		if err != nil {
+			var pathErr *fs.PathError
+			if errors.As(err, &pathErr) {
+				pathErr.Op = "readdir"
+			}
+			yield(nil, err)
+			return
+		}
+		defer dir.Close()
+		// ReadDir on the open handle returns entries in directory order.
+		// Sorting here is not optional: DirEntriesFS documents sorted output
+		// and WalkFiles depends on it. The previous implementation got the
+		// sort for free from fs.ReadDir, which sorts only when the FS does
+		// not implement ReadDirFS -- and os.DirFS does, sorting internally.
+		// Reading the handle directly skips both, so it is done explicitly.
+		entries, err := dir.ReadDir(-1)
+		slices.SortFunc(entries, func(a, b fs.DirEntry) int {
+			return strings.Compare(a.Name(), b.Name())
+		})
+		for _, entry := range entries {
+			if err := ctx.Err(); err != nil {
+				yield(nil, &fs.PathError{
+					Op:   "readdir",
+					Path: name,
+					Err:  err,
+				})
+				return
+			}
+			if !yield(entry, nil) {
+				return
+			}
+		}
+		// A partial read yields what it got and then the error, matching
+		// fs.ReadDir.
+		if err != nil {
+			yield(nil, err)
+		}
+	}
 }
 
 // Write writes the contents of src to the file named name, creating any
@@ -54,7 +176,7 @@ func (fsys *FS) Root() string {
 // The replacement happens in one step: src is copied to a unique temporary
 // file (".<base>.tmp-<random>") in the target's own directory, synced, and
 // then renamed over name once the copy is complete — an atomic replace on
-// POSIX and, via MoveFileEx(MOVEFILE_REPLACE_EXISTING), on Windows. A reader
+// POSIX and, via the replacing rename os.Root issues, on Windows. A reader
 // of name therefore observes either the previous file or the new file in
 // full, never a truncated or partially written one. A failed copy, a canceled
 // context or a crash before the rename leaves the previous contents
@@ -70,6 +192,10 @@ func (fsys *FS) Root() string {
 // through and neither its mode nor the link's own 0777 is copied onto the new
 // regular file.
 //
+// Every component of name is resolved inside the storage root, so a symlink
+// anywhere in the name — final component or intermediate directory — cannot
+// place the new file outside it.
+//
 // ctx is honored between reads from src: a canceled or expired context aborts
 // the copy and is reported as itself, so callers can match context.Canceled
 // and context.DeadlineExceeded. Cancellation is not observed during the final
@@ -78,12 +204,11 @@ func (fsys *FS) Root() string {
 // On any failure before the rename the returned count is 0: no bytes reached
 // name.
 func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, error) {
-	fullPath, err := fsys.osPath(name)
-	if err != nil {
+	if !fs.ValidPath(name) {
 		return 0, &fs.PathError{
 			Op:   "write",
 			Path: name,
-			Err:  err,
+			Err:  fs.ErrInvalid,
 		}
 	}
 	// "." names the storage root, never a file. fs.ValidPath accepts it, and
@@ -104,8 +229,11 @@ func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, e
 			Err:  err,
 		}
 	}
-	parent := filepath.Dir(fullPath)
-	if err := os.MkdirAll(parent, dirPerm); err != nil {
+	// Names are slash-separated fs.ValidPath names all the way down: os.Root
+	// takes them in that form on every platform, so nothing here converts to
+	// or from an OS-specific path.
+	parent := path.Dir(name)
+	if err := mkdirAll(fsys.root, parent); err != nil {
 		return 0, &fs.PathError{
 			Op:   "write",
 			Path: name,
@@ -132,14 +260,14 @@ func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, e
 		preserveMode fs.FileMode
 		havePerm     bool
 	)
-	if info, err := os.Lstat(fullPath); err == nil && info.Mode().IsRegular() {
+	if info, err := fsys.root.Lstat(name); err == nil && info.Mode().IsRegular() {
 		preserveMode, havePerm = info.Mode().Perm(), true
 	}
 	// The temp file goes in the target's own directory so the final rename
 	// is within one filesystem, where it is an atomic replace. O_EXCL at
 	// creation means it can never clobber an existing file, even if another
 	// writer races in the same directory.
-	tmpPath, tmp, err := createTempFile(parent, fullPath)
+	tmpName, tmp, err := createTempFile(fsys.root, parent, name)
 	if err != nil {
 		return 0, &fs.PathError{
 			Op:   "write",
@@ -152,11 +280,15 @@ func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, e
 	committed := false
 	defer func() {
 		if !committed {
-			_ = tmp.Close()        // no-op if already closed
-			_ = os.Remove(tmpPath) // no-op if already renamed away
+			_ = tmp.Close()               // no-op if already closed
+			_ = fsys.root.Remove(tmpName) // no-op if already renamed away
 		}
 	}()
 	if havePerm {
+		// Chmod on the open handle rather than Root.Chmod by name: this is
+		// fchmod on the file just created, which sidesteps the race os.Root's
+		// documentation warns about for Root.Chmod, where a name swapped to a
+		// symlink mid-operation can direct the chmod at the link's target.
 		if err := tmp.Chmod(preserveMode); err != nil {
 			return 0, &fs.PathError{
 				Op:   "write",
@@ -198,25 +330,30 @@ func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, e
 			Err:  err,
 		}
 	}
-	// The atomic swap. robustio.Rename is os.Rename plus a bounded retry
-	// (~2s, randomized backoff) on the transient Windows errors a virus
-	// scanner or the search indexer causes by holding a handle on the
-	// just-closed temp file: ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION,
-	// ERROR_FILE_NOT_FOUND. On darwin it retries ENOENT; on every other
-	// platform it is a plain call through to os.Rename.
+	// The atomic swap, resolved component-by-component inside the root on
+	// both sides, so neither the source nor the destination can be redirected
+	// out of it by a symlink.
 	//
-	// os.Rename is the right primitive on Windows too, contrary to a common
-	// belief that it cannot replace an existing file there: since Go 1.16 it
-	// is MoveFileEx(MOVEFILE_REPLACE_EXISTING) with fixLongPath applied, an
-	// atomic replace that also handles paths past MAX_PATH — which long OCFL
-	// content paths reach. This module requires Go 1.25 (see go.mod), well
-	// past that.
+	// Root.Rename is a replacing rename on Windows too: it is
+	// NtSetInformationFile with FileRenameInformationEx and
+	// FILE_RENAME_REPLACE_IF_EXISTS|FILE_RENAME_POSIX_SEMANTICS, falling back
+	// to FILE_RENAME_INFORMATION{ReplaceIfExists: true} on FAT and pre-1709
+	// NTFS. So the atomicity this method documents holds there as well, and
+	// the POSIX semantics additionally allow replacing a destination that has
+	// open handles, which MoveFileEx cannot. Long paths need no special
+	// handling: os.Root never expresses a name as one full path string, and
+	// the MAX_PATH bound in the rename structure applies only to the final
+	// component, which tempFileName already caps at 255 bytes.
 	//
-	// The retry sleeps without consulting ctx, so a canceled write can block
-	// here for up to ~2s. That is deliberate: the copy is already complete
-	// and the write is one syscall from committing, so finishing beats
-	// abandoning it.
-	if err := robustio.Rename(tmpPath, fullPath); err != nil {
+	// The bounded retry this call used to carry (robustio.Rename, for the
+	// transient ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION a Windows
+	// virus scanner causes by holding a handle, plus an ENOENT retry on
+	// darwin) is deliberately gone rather than reimplemented. CI is Linux
+	// plus a GOOS=windows vet, so the workaround could never be exercised;
+	// POSIX rename semantics remove the destination-side half of the problem
+	// outright; and the retry is reintroducible behind a build tag if a real
+	// failure ever shows up. See #164.
+	if err := fsys.root.Rename(tmpName, name); err != nil {
 		return 0, &fs.PathError{
 			Op:   "write",
 			Path: name,
@@ -229,7 +366,7 @@ func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, e
 	// as content while its name does not. Failures are ignored: the write
 	// has already succeeded, and not every filesystem supports fsync on a
 	// directory.
-	if dir, err := os.Open(parent); err == nil {
+	if dir, err := fsys.root.Open(parent); err == nil {
 		_ = dir.Sync()
 		_ = dir.Close()
 	}
@@ -266,7 +403,7 @@ func (r ctxReader) Read(p []byte) (int, error) {
 // rune, producing an invalid name that strict filesystems reject with a
 // confusing error.
 func tempFileName(target string) string {
-	base := filepath.Base(target)
+	base := path.Base(target)
 	const reserved = len(".") + len(".tmp-") + 16 // leading dot, suffix, hex random
 	if max := 255 - reserved; len(base) > max {
 		// Walk back from the byte limit to the nearest byte that starts a
@@ -283,16 +420,57 @@ func tempFileName(target string) string {
 	return "." + base + ".tmp-" + fmt.Sprintf("%016x", rand.Uint64())
 }
 
-// createTempFile creates a new file in dir named after target with
-// O_CREATE|O_EXCL|O_WRONLY, so it can never clobber an existing file. A name
-// collision (practically impossible) is retried with a fresh random suffix.
-// The file is created at tempPerm, subject to the process umask.
-func createTempFile(dir, target string) (string, *os.File, error) {
-	for range 10 {
-		path := filepath.Join(dir, tempFileName(target))
-		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, tempPerm)
+// mkdirAll creates the directory named dir inside root, along with any
+// missing parents, and reports success when it already exists as a directory.
+//
+// Root.MkdirAll is not used, because it races with itself on intermediate
+// components: for each parent it opens the component and, on ENOENT, calls
+// mkdirat once, returning EEXIST as an error if another goroutine created
+// that directory in between (go1.25 os/root_openat.go, openDirFunc). Two
+// concurrent writes under a common new prefix -- ordinary for a stage
+// commit -- then fail with "file exists". os.MkdirAll never had the problem
+// because it stats on EEXIST, which is what this does.
+//
+// Each component is created through root, so resolution stays inside the
+// storage root. An existing component that is not a directory, and one whose
+// symlink resolves outside the root (root.Stat fails), both surface as the
+// original EEXIST.
+func mkdirAll(root *os.Root, dir string) error {
+	if dir == "." {
+		return nil
+	}
+	built := ""
+	for part := range strings.SplitSeq(dir, "/") {
+		if built == "" {
+			built = part
+		} else {
+			built += "/" + part
+		}
+		err := root.Mkdir(built, dirPerm)
 		if err == nil {
-			return path, f, nil
+			continue
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return err
+		}
+		if info, statErr := root.Stat(built); statErr != nil || !info.IsDir() {
+			return err
+		}
+	}
+	return nil
+}
+
+// createTempFile creates a new file in dir (a name within root) named after
+// target with O_CREATE|O_EXCL|O_WRONLY, so it can never clobber an existing
+// file. A name collision (practically impossible) is retried with a fresh
+// random suffix. The file is created at tempPerm, subject to the process
+// umask.
+func createTempFile(root *os.Root, dir, target string) (string, *os.File, error) {
+	for range 10 {
+		name := path.Join(dir, tempFileName(target))
+		f, err := root.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, tempPerm)
+		if err == nil {
+			return name, f, nil
 		}
 		if !errors.Is(err, fs.ErrExist) {
 			return "", nil, err
@@ -301,13 +479,16 @@ func createTempFile(dir, target string) (string, *os.File, error) {
 	return "", nil, errors.New("unable to create a unique temp file")
 }
 
+// Remove removes the file named name. name is resolved inside the storage
+// root, so a symlink in an intermediate component cannot direct the removal
+// at a file outside it. A symlink at name itself is removed as the link entry
+// it is; its referent is untouched.
 func (fsys *FS) Remove(ctx context.Context, name string) error {
-	fullPath, err := fsys.osPath(name)
-	if err != nil {
+	if !fs.ValidPath(name) {
 		return &fs.PathError{
 			Op:   "remove",
 			Path: name,
-			Err:  err,
+			Err:  fs.ErrInvalid,
 		}
 	}
 	// "." names the storage root, never a file, so removing it is a bad
@@ -326,25 +507,31 @@ func (fsys *FS) Remove(ctx context.Context, name string) error {
 			Err:  err,
 		}
 	}
-	if err := os.Remove(fullPath); err != nil {
+	if err := fsys.root.Remove(name); err != nil {
 		return &fs.PathError{
 			Op:   "remove",
 			Path: name,
-			Err:  err,
+			Err:  unwrapPathError(err),
 		}
 	}
 	return nil
 }
 
+// RemoveAll removes name and any children it contains. name is resolved
+// inside the storage root, so a symlink in an intermediate component cannot
+// direct the removal at a tree outside it. A symlink at name itself is
+// removed as the link entry it is; the tree it points at is untouched.
 func (fsys *FS) RemoveAll(ctx context.Context, name string) error {
-	fullPath, err := fsys.osPath(name)
-	if err != nil {
+	if !fs.ValidPath(name) {
 		return &fs.PathError{
 			Op:   "remove",
 			Path: name,
-			Err:  err,
+			Err:  fs.ErrInvalid,
 		}
 	}
+	// The guard stays ahead of the Root call: Root.RemoveAll(".") reports a
+	// bare EINVAL that does not satisfy errors.Is(err, fs.ErrInvalid), so the
+	// refusal is spelled out here where callers can match it.
 	if name == "." {
 		return &fs.PathError{
 			Op:   "remove",
@@ -359,19 +546,23 @@ func (fsys *FS) RemoveAll(ctx context.Context, name string) error {
 			Err:  err,
 		}
 	}
-	if err := os.RemoveAll(fullPath + "/"); err != nil {
+	if err := fsys.root.RemoveAll(name); err != nil {
 		return &fs.PathError{
 			Op:   "remove",
 			Path: name,
-			Err:  err,
+			Err:  unwrapPathError(err),
 		}
 	}
 	return nil
 }
 
-func (fsys *FS) osPath(name string) (string, error) {
-	if !fs.ValidPath(name) {
-		return "", fs.ErrInvalid
+// unwrapPathError returns the underlying error of a *fs.PathError, so an
+// error from os.Root -- which reports its own Op and Path -- can be re-wrapped
+// with this package's without the two nesting.
+func unwrapPathError(err error) error {
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		return pathErr.Err
 	}
-	return filepath.Join(fsys.path, filepath.FromSlash(name)), nil
+	return err
 }

--- a/fs/local/localfs.go
+++ b/fs/local/localfs.go
@@ -34,6 +34,12 @@ const (
 // root. That holds for reads as well as writes — the difference from
 // [os.DirFS], whose documentation is explicit that it does follow symlinks out
 // of the directory it was given.
+//
+// One consequence is stricter than "stays inside the root": a symlink whose
+// target is an absolute path is refused even when that path names a file
+// inside the root, because os.Root treats any absolute target as leaving it.
+// Relative symlinks, chains included, resolve normally so long as every step
+// stays inside.
 type FS struct {
 	// path is the os-specific path to the root directory. It is kept for
 	// Root() and is never used to build a path handed to the OS.
@@ -233,6 +239,14 @@ func (fsys *FS) Write(ctx context.Context, name string, src io.Reader) (int64, e
 	// takes them in that form on every platform, so nothing here converts to
 	// or from an OS-specific path.
 	parent := path.Dir(name)
+	// Errors from here on keep the *fs.PathError os.Root reports, nested
+	// inside this method's own, rather than routing through unwrapPathError
+	// the way Remove and RemoveAll do. There the inner error names the same
+	// name the caller passed and is pure redundancy; here it names a
+	// different path worth keeping -- mkdirat reports the component that
+	// actually failed, and the temp file's create, chmod, sync and close
+	// report the temp file. Neither names the storage root, and errors.Is
+	// and errors.As see through either shape.
 	if err := mkdirAll(fsys.root, parent); err != nil {
 		return 0, &fs.PathError{
 			Op:   "write",

--- a/fs/local/localfs_symlink_test.go
+++ b/fs/local/localfs_symlink_test.go
@@ -163,3 +163,205 @@ func TestFS_Write_ToleratesLstatError(t *testing.T) {
 	be.NilErr(t, err)
 	be.Equal(t, "x", string(data))
 }
+
+// The tests below pin containment: a symlink inside the storage root must
+// never let a name reach a file outside it. Each one builds the same shape --
+// an "outside" directory next to the root, a symlink in the root pointing at
+// it -- and asserts both halves of the guarantee: the operation fails, and
+// the external target is exactly as it was.
+//
+// They assert a non-nil error rather than a sentinel deliberately. os.Root
+// reports an escape as an unexported errors.errorString ("path escapes from
+// parent") that matches none of fs.ErrNotExist, fs.ErrInvalid or
+// fs.ErrPermission, and the error a caller actually gets varies by method:
+// writing through an intermediate symlink fails in MkdirAll with "file
+// exists", not with the escape error at all. Pinning any particular error
+// would pin an implementation detail of the standard library; the surviving
+// external state is the property that matters.
+
+// escapeFixture builds a root containing "link" -> outside, where outside
+// holds a file "secret" and a directory "subdir" with a file in it. It
+// returns the FS, the root path and the outside path.
+func escapeFixture(t *testing.T) (*FS, string, string) {
+	t.Helper()
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	outside := filepath.Join(base, "outside")
+	be.NilErr(t, os.MkdirAll(root, 0o755))
+	be.NilErr(t, os.MkdirAll(filepath.Join(outside, "subdir"), 0o755))
+	be.NilErr(t, os.WriteFile(filepath.Join(outside, "secret"), []byte("secret data"), 0o600))
+	be.NilErr(t, os.WriteFile(filepath.Join(outside, "subdir", "nested"), []byte("nested data"), 0o600))
+	be.NilErr(t, os.Symlink(outside, filepath.Join(root, "link")))
+	return MustNewFS(root), root, outside
+}
+
+// assertOutsideIntact checks that nothing under outside was created, removed
+// or modified.
+func assertOutsideIntact(t *testing.T, outside string) {
+	t.Helper()
+	secret, err := os.ReadFile(filepath.Join(outside, "secret"))
+	be.NilErr(t, err)
+	be.Equal(t, "secret data", string(secret))
+	nested, err := os.ReadFile(filepath.Join(outside, "subdir", "nested"))
+	be.NilErr(t, err)
+	be.Equal(t, "nested data", string(nested))
+	entries, err := os.ReadDir(outside)
+	be.NilErr(t, err)
+	be.Equal(t, 2, len(entries)) // secret, subdir -- nothing new
+}
+
+// TestFS_Write_IntermediateSymlinkEscape: Write("link/pwned.txt") created
+// outside/pwned.txt before the FS was rebuilt on os.Root.
+func TestFS_Write_IntermediateSymlinkEscape(t *testing.T) {
+	fsys, _, outside := escapeFixture(t)
+	_, err := fsys.Write(context.Background(), "link/pwned.txt", strings.NewReader("pwned"))
+	be.True(t, err != nil)
+	if _, statErr := os.Lstat(filepath.Join(outside, "pwned.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("write through an intermediate symlink created a file outside the root")
+	}
+	assertOutsideIntact(t, outside)
+}
+
+// TestFS_Remove_IntermediateSymlinkEscape: Remove("link/secret") deleted
+// outside/secret before the rebuild.
+func TestFS_Remove_IntermediateSymlinkEscape(t *testing.T) {
+	fsys, _, outside := escapeFixture(t)
+	err := fsys.Remove(context.Background(), "link/secret")
+	be.True(t, err != nil)
+	assertOutsideIntact(t, outside)
+}
+
+// TestFS_RemoveAll_IntermediateSymlinkEscape: RemoveAll("link/subdir")
+// deleted outside/subdir and returned nil before the rebuild -- the worst of
+// the four, since the caller saw success.
+func TestFS_RemoveAll_IntermediateSymlinkEscape(t *testing.T) {
+	fsys, _, outside := escapeFixture(t)
+	err := fsys.RemoveAll(context.Background(), "link/subdir")
+	be.True(t, err != nil)
+	assertOutsideIntact(t, outside)
+}
+
+// TestFS_Read_IntermediateSymlinkEscape covers the read path, which os.DirFS
+// documents as following symlinks out of the directory it was given.
+func TestFS_Read_IntermediateSymlinkEscape(t *testing.T) {
+	fsys, _, outside := escapeFixture(t)
+	ctx := context.Background()
+
+	t.Run("OpenFile", func(t *testing.T) {
+		f, err := fsys.OpenFile(ctx, "link/secret")
+		if err == nil {
+			f.Close()
+			t.Fatal("OpenFile read a file outside the storage root")
+		}
+	})
+
+	t.Run("DirEntries", func(t *testing.T) {
+		var (
+			got     []string
+			dirErr  error
+			entries = fsys.DirEntries(ctx, "link")
+		)
+		for entry, err := range entries {
+			if err != nil {
+				dirErr = err
+				continue
+			}
+			got = append(got, entry.Name())
+		}
+		be.True(t, dirErr != nil)
+		be.Equal(t, 0, len(got))
+	})
+
+	// Reading the link itself is equally an escape: the target is outside.
+	t.Run("OpenFile on the link", func(t *testing.T) {
+		f, err := fsys.OpenFile(ctx, "link")
+		if err == nil {
+			f.Close()
+			t.Fatal("OpenFile followed a symlink out of the storage root")
+		}
+	})
+
+	assertOutsideIntact(t, outside)
+}
+
+// TestFS_Remove_SymlinkAtName pins the other half of removal: a symlink named
+// directly is removed as the link entry it is, leaving its referent -- even an
+// external one -- untouched. This is not an escape and must succeed.
+func TestFS_Remove_SymlinkAtName(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		remove func(*FS, context.Context) error
+	}{
+		{"Remove", func(fsys *FS, ctx context.Context) error { return fsys.Remove(ctx, "link") }},
+		{"RemoveAll", func(fsys *FS, ctx context.Context) error { return fsys.RemoveAll(ctx, "link") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fsys, root, outside := escapeFixture(t)
+			be.NilErr(t, tc.remove(fsys, context.Background()))
+			if _, err := os.Lstat(filepath.Join(root, "link")); !os.IsNotExist(err) {
+				t.Fatalf("link entry still present after %s", tc.name)
+			}
+			assertOutsideIntact(t, outside)
+		})
+	}
+}
+
+// TestFS_Write_SymlinkAtNameToExternalTarget covers the case the existing
+// mode tests do not: the target name is a symlink whose referent is outside
+// the root. The write must replace the link entry with a regular file inside
+// the root and leave the external referent's contents and mode alone. It is
+// not an escape -- the rename never follows the final component -- so it
+// succeeds.
+func TestFS_Write_SymlinkAtNameToExternalTarget(t *testing.T) {
+	fsys, root, outside := escapeFixture(t)
+	referent := filepath.Join(outside, "secret")
+	be.NilErr(t, os.Symlink(referent, filepath.Join(root, "target")))
+
+	n, err := fsys.Write(context.Background(), "target", strings.NewReader("replacement"))
+	be.NilErr(t, err)
+	be.Equal(t, int64(len("replacement")), n)
+
+	// The name now holds a regular file inside the root with the new bytes.
+	info, err := os.Lstat(filepath.Join(root, "target"))
+	be.NilErr(t, err)
+	if info.Mode()&fs.ModeSymlink != 0 {
+		t.Fatal("write left a symlink at the target name")
+	}
+	data, err := os.ReadFile(filepath.Join(root, "target"))
+	be.NilErr(t, err)
+	be.Equal(t, "replacement", string(data))
+
+	// The external referent kept both its contents and its mode: nothing was
+	// written through the link, and its 0600 did not become the new file's.
+	refData, err := os.ReadFile(referent)
+	be.NilErr(t, err)
+	be.Equal(t, "secret data", string(refData))
+	refInfo, err := os.Stat(referent)
+	be.NilErr(t, err)
+	be.Equal(t, fs.FileMode(0o600), refInfo.Mode().Perm())
+	if info.Mode().Perm() == 0o600 {
+		t.Fatalf("external referent's mode leaked onto the replacement: %v", info.Mode().Perm())
+	}
+	assertOutsideIntact(t, outside)
+}
+
+// TestFS_DirEntries_Sorted guards the trap in reading a directory handle
+// directly: os.DirFS implements ReadDirFS and sorts internally, so the
+// previous implementation got sorted output for free. os.File.ReadDir does
+// not sort, so DirEntries sorts explicitly -- and this pins it, with names
+// written in an order that is not the sorted one.
+func TestFS_DirEntries_Sorted(t *testing.T) {
+	fsys := MustNewFS(t.TempDir())
+	ctx := context.Background()
+	for _, name := range []string{"zulu", "alpha", "mike", "bravo", "delta"} {
+		_, err := fsys.Write(ctx, "d/"+name, strings.NewReader(name))
+		be.NilErr(t, err)
+	}
+	var got []string
+	for entry, err := range fsys.DirEntries(ctx, "d") {
+		be.NilErr(t, err)
+		got = append(got, entry.Name())
+	}
+	want := []string{"alpha", "bravo", "delta", "mike", "zulu"}
+	be.Equal(t, strings.Join(want, ","), strings.Join(got, ","))
+}

--- a/fs/local/localfs_test.go
+++ b/fs/local/localfs_test.go
@@ -5,9 +5,13 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +37,21 @@ func TestNewFS(t *testing.T) {
 		root := fsys.Root()
 		be.True(t, filepath.IsAbs(root))
 		be.True(t, strings.HasSuffix(root, filepath.Base(tmpDir)))
+	})
+
+	// NewFS now opens an os.Root on the directory, so a path that is not an
+	// existing directory fails here rather than at the first operation on it.
+	t.Run("rejects a missing directory", func(t *testing.T) {
+		_, err := NewFS(filepath.Join(t.TempDir(), "no-such-dir"))
+		be.True(t, err != nil)
+		be.True(t, errors.Is(err, fs.ErrNotExist))
+	})
+
+	t.Run("rejects a path that is not a directory", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "regular.txt")
+		be.NilErr(t, os.WriteFile(file, []byte("x"), 0o644))
+		_, err := NewFS(file)
+		be.True(t, err != nil)
 	})
 }
 
@@ -389,42 +408,74 @@ func TestFS_RemoveAll(t *testing.T) {
 	})
 }
 
-func TestFS_osPath(t *testing.T) {
-	t.Run("converts valid fs path to OS path", func(t *testing.T) {
+// TestFS_NameResolution replaces the old TestFS_osPath. Names are no longer
+// turned into an OS path at all: every method hands the slash-separated name
+// to the FS's os.Root, which resolves it one component at a time. What is
+// left to pin is the observable half of what osPath did — a valid name lands
+// under the storage root at the place its components name, and an invalid one
+// is rejected as fs.ErrInvalid by every method rather than reaching the OS.
+func TestFS_NameResolution(t *testing.T) {
+	t.Run("nested name lands under the root", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		fsys, err := NewFS(tmpDir)
 		be.NilErr(t, err)
 
-		osPath, err := fsys.osPath("test.txt")
+		ctx := context.Background()
+		_, err = fsys.Write(ctx, "a/b/c/test.txt", strings.NewReader("nested"))
 		be.NilErr(t, err)
-		be.Equal(t, filepath.Join(tmpDir, "test.txt"), osPath)
+
+		data, err := os.ReadFile(filepath.Join(tmpDir, "a", "b", "c", "test.txt"))
+		be.NilErr(t, err)
+		be.Equal(t, "nested", string(data))
 	})
 
-	t.Run("handles nested paths", func(t *testing.T) {
+	t.Run("invalid names are rejected by every method", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		fsys, err := NewFS(tmpDir)
 		be.NilErr(t, err)
 
-		osPath, err := fsys.osPath("a/b/c/test.txt")
-		be.NilErr(t, err)
-		expected := filepath.Join(tmpDir, "a", "b", "c", "test.txt")
-		be.Equal(t, expected, osPath)
-	})
-
-	t.Run("rejects invalid paths", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		fsys, err := NewFS(tmpDir)
-		be.NilErr(t, err)
-
-		invalidPaths := []string{
+		ctx := context.Background()
+		invalidNames := []string{
 			"../outside",
 			"/absolute",
+			"./file",
+			"",
 		}
-
-		for _, path := range invalidPaths {
-			_, err := fsys.osPath(path)
-			be.True(t, err != nil)
-			be.Equal(t, fs.ErrInvalid, err)
+		for _, name := range invalidNames {
+			ops := map[string]error{
+				"write": func() error {
+					_, err := fsys.Write(ctx, name, strings.NewReader("x"))
+					return err
+				}(),
+				"remove":    fsys.Remove(ctx, name),
+				"removeall": fsys.RemoveAll(ctx, name),
+				"openfile": func() error {
+					_, err := fsys.OpenFile(ctx, name)
+					return err
+				}(),
+			}
+			for _, entry := range slices.Sorted(maps.Keys(ops)) {
+				opErr := ops[entry]
+				if opErr == nil {
+					t.Fatalf("%s(%q) = nil, want an error", entry, name)
+				}
+				var pathErr *fs.PathError
+				be.True(t, errors.As(opErr, &pathErr))
+				be.Equal(t, name, pathErr.Path)
+				if !errors.Is(opErr, fs.ErrInvalid) {
+					t.Fatalf("%s(%q) = %v, want fs.ErrInvalid", entry, name, opErr)
+				}
+			}
+			// DirEntries reports the same rejection through its iterator.
+			var dirErr error
+			for _, err := range fsys.DirEntries(ctx, name) {
+				if err != nil {
+					dirErr = err
+				}
+			}
+			if !errors.Is(dirErr, fs.ErrInvalid) {
+				t.Fatalf("DirEntries(%q) = %v, want fs.ErrInvalid", name, dirErr)
+			}
 		}
 	})
 }
@@ -447,4 +498,105 @@ func TestFS_Implements_Interfaces(t *testing.T) {
 	data, err := io.ReadAll(f)
 	be.NilErr(t, err)
 	be.Equal(t, "test", string(data))
+}
+
+// TestFS_Write_ConcurrentNestedWrites pins the tolerance mkdirAll adds over
+// Root.MkdirAll. Root.MkdirAll opens each intermediate component and, on
+// ENOENT, calls mkdirat exactly once, reporting EEXIST as an error if another
+// goroutine created that directory in between -- so two concurrent writes
+// under a common new prefix fail with "file exists". Writing an object
+// version does exactly that, which is how this surfaced.
+func TestFS_Write_ConcurrentNestedWrites(t *testing.T) {
+	fsys, err := NewFS(t.TempDir())
+	be.NilErr(t, err)
+	ctx := context.Background()
+
+	// A deep shared prefix widens the window: every writer must create the
+	// same chain of missing parents.
+	const prefix = "obj/v2/content/docs/deep"
+	const writers = 16
+
+	start := make(chan struct{})
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			name := prefix + "/file-" + strconv.Itoa(i) + ".txt"
+			_, err := fsys.Write(ctx, name, strings.NewReader(name))
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		be.NilErr(t, err)
+	}
+
+	for i := range writers {
+		name := prefix + "/file-" + strconv.Itoa(i) + ".txt"
+		data, err := os.ReadFile(filepath.Join(fsys.Root(), filepath.FromSlash(name)))
+		be.NilErr(t, err)
+		be.Equal(t, name, string(data))
+	}
+}
+
+// TestFS_Write_ParentExistsAsFile pins the other side of mkdirAll's EEXIST
+// handling: tolerating an existing directory must not tolerate an existing
+// regular file standing where a parent directory belongs.
+func TestFS_Write_ParentExistsAsFile(t *testing.T) {
+	fsys, err := NewFS(t.TempDir())
+	be.NilErr(t, err)
+	ctx := context.Background()
+
+	_, err = fsys.Write(ctx, "blocker", strings.NewReader("x"))
+	be.NilErr(t, err)
+
+	_, err = fsys.Write(ctx, "blocker/child.txt", strings.NewReader("y"))
+	be.True(t, err != nil)
+	var pathErr *fs.PathError
+	be.True(t, errors.As(err, &pathErr))
+	be.Equal(t, "write", pathErr.Op)
+	be.Equal(t, "blocker/child.txt", pathErr.Path)
+}
+
+// TestFS_Close pins the descriptor lifecycle NewFS introduces: Close releases
+// the root, after which operations fail rather than silently succeeding, and
+// a second Close is harmless.
+func TestFS_Close(t *testing.T) {
+	fsys, err := NewFS(t.TempDir())
+	be.NilErr(t, err)
+	ctx := context.Background()
+
+	_, err = fsys.Write(ctx, "before.txt", strings.NewReader("x"))
+	be.NilErr(t, err)
+
+	be.NilErr(t, fsys.Close())
+	be.NilErr(t, fsys.Close()) // idempotent
+
+	_, err = fsys.Write(ctx, "after.txt", strings.NewReader("x"))
+	be.True(t, err != nil)
+	_, err = fsys.OpenFile(ctx, "before.txt")
+	be.True(t, err != nil)
+}
+
+// TestMustNewFS covers both halves of the Must contract.
+func TestMustNewFS(t *testing.T) {
+	t.Run("returns an FS for an existing directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		fsys := MustNewFS(tmpDir)
+		be.Equal(t, tmpDir, fsys.Root())
+	})
+
+	t.Run("panics when the directory is missing", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("MustNewFS did not panic on a missing directory")
+			}
+		}()
+		MustNewFS(filepath.Join(t.TempDir(), "no-such-dir"))
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/aws/smithy-go v1.27.3
 	github.com/carlmjohnson/be v0.23.2
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/rogpeppe/go-internal v1.16.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sync v0.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/rogpeppe/go-internal v1.16.0 h1:O9DK+vNMDVGLr2BeZqmpLeMjiMNkuXfcqntWbZV6S5g=
-github.com/rogpeppe/go-internal v1.16.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=


### PR DESCRIPTION
A symlink inside a storage root let a name inside the root reach data
outside it. Every method built one full OS path with filepath.Join and
handed the string to the kernel, which follows a symlink at any
component, so the escape was reachable four ways: the os.DirFS read path
(documented as following links out of the directory), and an
intermediate symlink in Write, Remove and RemoveAll -- RemoveAll being
the worst, deleting an external tree and returning nil.

FS now holds a single *os.Root opened in NewFS and every method goes
through it. os.Root resolves a name component by component with the
openat family, refusing any component whose symlink leaves the root, so
the whole class is closed rather than four symptoms patched. The
embedded ocflfs.DirEntriesFS and its os.DirFS go away: OpenFile and
DirEntries are implemented directly on the root, which removes the last
escape-prone constructor from the package.

DirEntries sorts explicitly. The sort used to come free from
fs.ReadDir, which sorts only when the FS lacks ReadDirFS -- os.DirFS has
it and sorts internally. Reading the directory handle directly gets no
sort, which would silently break the DirEntriesFS contract and
WalkFiles ordering.

Write keeps every guarantee #163 established -- the "." rejection, the
temp-file-plus-rename, Lstat-based mode preservation, Sync before
rename, the parent fsync -- with paths now slash-separated, since
os.Root takes fs.ValidPath names on every platform. The mode chmod uses
the open handle (fchmod) rather than Root.Chmod by name, avoiding the
race os.Root documents for the latter.

Parent directories are created by a local mkdirAll rather than
Root.MkdirAll: for an intermediate component the stdlib opens it and,
on ENOENT, calls mkdirat exactly once, so a directory another goroutine
created in between comes back as EEXIST. Concurrent writes under a
common new prefix -- what committing an object version does -- failed
with "file exists". The replacement stats on EEXIST, as os.MkdirAll
always did, and still creates each component through the root.

The robustio rename retry is dropped rather than reimplemented. It
covered transient Windows errors from a scanner holding a handle, plus
an ENOENT retry on darwin, and CI is Linux plus a GOOS=windows vet, so
it could never be exercised. Root.Rename is a replacing rename on
Windows (FileRenameInformationEx with POSIX semantics), which keeps the
atomicity Write documents and additionally replaces a destination with
open handles. It was the only use of go-internal, now out of go.mod.

NewFS gains a contract: path must exist and be a directory, since
os.OpenRoot opens a descriptor on it. Every in-tree caller already
passes one, and examples/update turns a bad user-supplied path into a
fail-fast. FS also owns that descriptor now, so Close is added; a
caller who never calls it is reclaimed by os.Root's finalizer, as with
an os.File. MustNewFS joins it, following MustParseVNum.

New tests build a root with a symlink to an external directory and
assert both halves for Write, Remove, RemoveAll, OpenFile and
DirEntries: the operation errors and the external tree is byte-for-byte
intact. They assert a non-nil error, not a sentinel -- os.Root reports
an escape as an unexported error matching none of fs.ErrNotExist,
fs.ErrInvalid or fs.ErrPermission, and Write fails earlier still, in
mkdir with "file exists". Also covered: a symlink at the name itself is
removed as a link entry and written over without touching its external
referent, DirEntries ordering, the concurrent-nested-write regression,
and the NewFS/Close/MustNewFS lifecycle. TestFS_osPath is replaced by
TestFS_NameResolution, which pins what osPath was observable for.

## Upgrade note

Two user-visible tightenings, both intended, worth a line in the release
notes:

- **A symlink whose target is an absolute path now fails, even when that
  path names a file inside the root.** os.Root treats any absolute
  target as leaving the root and cannot distinguish "absolute but
  contained" from an escape. Relative symlinks are unaffected, chains
  included -- the repo's own testdata/content-fixture hidden_link.txt
  still resolves -- as is writing over a dangling symlink.
- **NewFS is now fail-fast** on a missing or non-directory path, since
  os.OpenRoot opens the descriptor in the constructor rather than at the
  first read or write.

Fixes #164