### PR TITLE
fs: fix fileWalk nil-deref on an error-yielding DirEntries

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -245,6 +245,10 @@ func fileWalk(ctx context.Context, fsys FS, walkRoot string, subDir string, yiel
 			if !yield(nil, err) {
 				return false
 			}
+			continue
+		}
+		if e == nil {
+			continue
 		}
 		entryPath := path.Join(subDir, e.Name())
 		switch {
@@ -258,6 +262,7 @@ func fileWalk(ctx context.Context, fsys FS, walkRoot string, subDir string, yiel
 				if !yield(nil, err) {
 					return false
 				}
+				continue
 			}
 			ref := &FileRef{
 				FS:      fsys,

--- a/fs/internal/imptest/filewalker.go
+++ b/fs/internal/imptest/filewalker.go
@@ -136,11 +136,6 @@ func TestWalkFiles(t *testing.T, fsys ocflfs.WriteFS, opts WalkFiles) {
 	})
 
 	t.Run("walk errors are delivered and terminate iteration", func(t *testing.T) {
-		// TODO(#165): fileWalk yields the directory-read error and then falls
-		// through to e.Name() on the nil entry it was yielded with, so the
-		// local walk panics instead of terminating. The s3 backend already
-		// satisfies this; drop the skip when #165 fixes the nil deref.
-		t.Skip("fileWalk panics on an error-yielding DirEntries; see #165")
 		// The fixture's walk of "blocked" fails: s3's ListObjectsV2 errors on
 		// that prefix, local's directory read of a regular file fails.
 		got := walkAll(opts.ErrWalk(t), "blocked")

--- a/fs/internal/imptest/imptest.go
+++ b/fs/internal/imptest/imptest.go
@@ -58,10 +58,7 @@
 // already satisfies is skipped for both — the TODO says which, so the fixing
 // PR knows what it is turning on. Writing the test now and skipping it is the
 // point: the PR that fixes the defect deletes one line, and its diff shows
-// exactly which behavior it makes good on. The s3 Remove skip above (#166)
-// stands at the moment; local Write atomicity (#163) and the fileWalk
-// nil-deref (#173) were the other two until each landed and turned its
-// subtests on.
+// exactly which behavior it makes good on.
 //
 // # Import direction
 //

--- a/fs/internal/imptest/imptest.go
+++ b/fs/internal/imptest/imptest.go
@@ -58,9 +58,9 @@
 // already satisfies is skipped for both — the TODO says which, so the fixing
 // PR knows what it is turning on. Writing the test now and skipping it is the
 // point: the PR that fixes the defect deletes one line, and its diff shows
-// exactly which behavior it makes good on. Two stand at the moment — the
-// fileWalk nil-deref (#165) and the s3 Remove above (#166); local Write
-// atomicity (#163) was the third until #163 landed and turned its two
+// exactly which behavior it makes good on. The s3 Remove skip above (#166)
+// stands at the moment; local Write atomicity (#163) and the fileWalk
+// nil-deref (#173) were the other two until each landed and turned its
 // subtests on.
 //
 // # Import direction

--- a/fs/local/localfs.go
+++ b/fs/local/localfs.go
@@ -169,8 +169,17 @@ func (fsys *FS) DirEntries(ctx context.Context, name string) iter.Seq2[fs.DirEnt
 			}
 		}
 		// A partial read yields what it got and then the error, matching
-		// fs.ReadDir.
+		// fs.ReadDir. Unlike root.Open's error above, the handle's ReadDir
+		// error carries the OS-level path (e.g. reading a regular file as a
+		// directory yields "readdirent <tmpdir>/blocked: not a directory"),
+		// so both Op and Path need rewriting to keep the storage root out of
+		// the error and match the name the caller passed in.
 		if err != nil {
+			var pathErr *fs.PathError
+			if errors.As(err, &pathErr) {
+				pathErr.Op = "readdir"
+				pathErr.Path = name
+			}
 			yield(nil, err)
 		}
 	}

--- a/fs/walk_test.go
+++ b/fs/walk_test.go
@@ -70,12 +70,6 @@ type walkYield struct {
 //   - never produce a FileRef with a nil Info field after an Info() error,
 //   - keep walking valid entries after error yields.
 func TestWalkFiles_DirEntriesError(t *testing.T) {
-	// TODO(#165): the (nil, err) yield is propagated and then falls through
-	// to path.Join(subDir, e.Name()) on the nil entry, so the walk panics; an
-	// Info() error produces a *FileRef with a nil Info field. Drop the skip
-	// when #165 fixes both.
-	t.Skip("fileWalk panics on an error-yielding DirEntries; see #165")
-
 	errYield := errors.New("direntries: listing failed")
 	errInfo := errors.New("direntries: stat failed")
 


### PR DESCRIPTION
fileWalk fell through to e.Name() and e.Info() after yielding a nil
entry's error, panicking on any error-yielding DirEntriesFS -- which
DirEntriesFS's own contract permits and ocflfs.DirEntries produces
whenever fsys isn't a DirEntriesFS. Continue after each error yield
instead, and skip a nil entry paired with a nil error defensively.

Unskipping the regression tests this unblocks also exposed that
local.FS.DirEntries didn't normalize the Op/Path on a ReadDir error
the way it does for Open's, so a listing failure leaked the absolute
OS path instead of the name the caller passed in. Fixed alongside,
since it's the same walk-error contract the unskipped tests assert.

Fixes #173.