### PR TITLE
fs: replace Copy's == backend comparison with a SameBackend interface

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -91,17 +91,29 @@ type CopyFS interface {
 	Copy(ctx context.Context, dst string, src string) (int64, error)
 }
 
-// Copy copies src in srcFS to dst in dstFS. If srcFS and dstFS are the same refererence
-// and it implements CopyFS, then Copy uses the fs's Copy() method.
+// SameBackend is an optional interface an FS implementation can use to report
+// whether other refers to the same underlying storage backend as the
+// receiver.
+type SameBackend interface {
+	// SameBackend returns true if other refers to the same underlying storage
+	// backend as the receiver. Implementations must return false if they
+	// cannot determine that other shares the receiver's backend; never
+	// assume.
+	SameBackend(other FS) bool
+}
+
+// Copy copies src in srcFS to dst in dstFS. If dstFS implements CopyFS and
+// SameBackend, and dstFS.SameBackend(srcFS) reports true, Copy uses dstFS's
+// Copy method. Otherwise, Copy reads src from srcFS and writes it to dstFS.
 func Copy(ctx context.Context, dstFS FS, dst string, srcFS FS, src string) (size int64, err error) {
-	cpFS, ok := dstFS.(CopyFS)
-	// FIXME: better way to compare src and dst FS
-	if ok && dstFS == srcFS {
-		size, err = cpFS.Copy(ctx, dst, src)
-		if err != nil {
-			err = fmt.Errorf("during copy: %w", err)
+	if cpFS, ok := dstFS.(CopyFS); ok {
+		if sb, ok := dstFS.(SameBackend); ok && sb.SameBackend(srcFS) {
+			size, err = cpFS.Copy(ctx, dst, src)
+			if err != nil {
+				err = fmt.Errorf("during copy: %w", err)
+			}
+			return
 		}
-		return
 	}
 	// otherwise, manual copy
 	var srcF fs.File

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -1,0 +1,138 @@
+package fs_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/fs"
+	"testing"
+
+	"github.com/carlmjohnson/be"
+	ocflfs "github.com/srerickson/ocfl-go/fs"
+)
+
+// spySrcFS serves body from OpenFile, regardless of the name requested. It's
+// used as srcFS in Copy dispatch tests, where only the dispatch decision --
+// not the name resolution -- is under test.
+type spySrcFS struct {
+	body []byte
+}
+
+func (s *spySrcFS) OpenFile(_ context.Context, _ string) (fs.File, error) {
+	return &spyFile{r: bytes.NewReader(s.body)}, nil
+}
+
+type spyFile struct {
+	r *bytes.Reader
+}
+
+func (f *spyFile) Read(p []byte) (int, error) { return f.r.Read(p) }
+func (f *spyFile) Close() error               { return nil }
+func (f *spyFile) Stat() (fs.FileInfo, error) { return nil, fs.ErrInvalid }
+
+var _ ocflfs.FS = (*spySrcFS)(nil)
+
+// spyCopyFS is a WriteFS/CopyFS spy used as dstFS in Copy dispatch tests. It
+// does not implement SameBackend.
+type spyCopyFS struct {
+	written    bytes.Buffer
+	copyCalled bool
+}
+
+func (d *spyCopyFS) OpenFile(context.Context, string) (fs.File, error) { return nil, fs.ErrNotExist }
+
+func (d *spyCopyFS) Write(_ context.Context, _ string, r io.Reader) (int64, error) {
+	return io.Copy(&d.written, r)
+}
+
+func (d *spyCopyFS) Remove(context.Context, string) error    { return nil }
+func (d *spyCopyFS) RemoveAll(context.Context, string) error { return nil }
+
+func (d *spyCopyFS) Copy(context.Context, string, string) (int64, error) {
+	d.copyCalled = true
+	return 0, nil
+}
+
+var (
+	_ ocflfs.FS     = (*spyCopyFS)(nil)
+	_ ocflfs.CopyFS = (*spyCopyFS)(nil)
+)
+
+// spySameBackendFS wraps spyCopyFS and additionally implements SameBackend,
+// reporting whatever result is configured.
+type spySameBackendFS struct {
+	spyCopyFS
+	result bool
+}
+
+func (d *spySameBackendFS) SameBackend(ocflfs.FS) bool { return d.result }
+
+var _ ocflfs.SameBackend = (*spySameBackendFS)(nil)
+
+func TestCopyDispatch(t *testing.T) {
+	ctx := context.Background()
+	src := &spySrcFS{body: []byte("hello")}
+
+	t.Run("same backend uses dstFS.Copy", func(t *testing.T) {
+		dst := &spySameBackendFS{result: true}
+		_, err := ocflfs.Copy(ctx, dst, "dst", src, "src")
+		be.NilErr(t, err)
+		be.True(t, dst.copyCalled)
+		be.Equal(t, 0, dst.written.Len())
+	})
+
+	t.Run("different backend falls back to write", func(t *testing.T) {
+		dst := &spySameBackendFS{result: false}
+		_, err := ocflfs.Copy(ctx, dst, "dst", src, "src")
+		be.NilErr(t, err)
+		be.False(t, dst.copyCalled)
+		be.Equal(t, "hello", dst.written.String())
+	})
+
+	t.Run("dstFS without SameBackend falls back to write", func(t *testing.T) {
+		dst := &spyCopyFS{}
+		_, err := ocflfs.Copy(ctx, dst, "dst", src, "src")
+		be.NilErr(t, err)
+		be.False(t, dst.copyCalled)
+		be.Equal(t, "hello", dst.written.String())
+	})
+}
+
+// noncmpFS is a WriteFS/CopyFS whose dynamic type carries a map field, so it
+// is not comparable with ==. It reproduces the original defect: the previous
+// dstFS == srcFS comparison panicked comparing two values of the same
+// non-comparable dynamic type, which happens whenever the same *noncmpFS is
+// used as both src and dst.
+type noncmpFS struct {
+	m map[string]string
+}
+
+func (n *noncmpFS) OpenFile(context.Context, string) (fs.File, error) {
+	return &spyFile{r: bytes.NewReader([]byte("x"))}, nil
+}
+
+func (n *noncmpFS) Write(_ context.Context, _ string, r io.Reader) (int64, error) {
+	return io.Copy(io.Discard, r)
+}
+
+func (n *noncmpFS) Remove(context.Context, string) error    { return nil }
+func (n *noncmpFS) RemoveAll(context.Context, string) error { return nil }
+
+func (n *noncmpFS) Copy(context.Context, string, string) (int64, error) {
+	return 0, nil
+}
+
+var (
+	_ ocflfs.FS     = (*noncmpFS)(nil)
+	_ ocflfs.CopyFS = (*noncmpFS)(nil)
+)
+
+func TestCopyDispatch_NonComparableDynamicType(t *testing.T) {
+	ctx := context.Background()
+	fsys := &noncmpFS{m: map[string]string{}}
+	// fsys does not implement SameBackend, so Copy falls back to the manual
+	// path regardless of dst/src identity -- the point of the test is that
+	// it does not panic getting there.
+	_, err := ocflfs.Copy(ctx, fsys, "dst", fsys, "src")
+	be.NilErr(t, err)
+}

--- a/fs/local/localfs.go
+++ b/fs/local/localfs.go
@@ -50,6 +50,7 @@ type FS struct {
 
 var _ ocflfs.WriteFS = (*FS)(nil)
 var _ ocflfs.DirEntriesFS = (*FS)(nil)
+var _ ocflfs.SameBackend = (*FS)(nil)
 
 // NewFS returns an FS for the directory at path, which must exist and be a
 // directory: the [os.Root] opened here holds a descriptor on it, so a missing
@@ -88,6 +89,20 @@ func (fsys *FS) Close() error {
 
 func (fsys *FS) Root() string {
 	return fsys.path
+}
+
+// SameBackend implements [ocflfs.SameBackend] for fsys. It reports true if
+// other is a *FS opened at the same absolute path.
+//
+// This is a conservative predicate, not a guarantee: it cannot see through
+// bind mounts or hard links, and it reports true for two roots opened at the
+// same path even if the directory was replaced between constructions.
+func (fsys *FS) SameBackend(other ocflfs.FS) bool {
+	o, ok := other.(*FS)
+	if !ok {
+		return false
+	}
+	return fsys.path == o.path
 }
 
 // OpenFile opens the named file for reading. name is resolved inside the

--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"iter"
 	"log/slog"
+	"reflect"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -103,6 +104,35 @@ func (f *BucketFS) Remove(ctx context.Context, name string) error {
 func (f *BucketFS) RemoveAll(ctx context.Context, name string) error {
 	f.debugLog(ctx, "s3:remove_all", "bucket", f.bucket, "name", name)
 	return removeAll(ctx, f.client, f.bucket, name)
+}
+
+// SameBackend implements [ocflfs.SameBackend] for f. It reports true if other
+// is a *BucketFS naming the same bucket, using the same client. Client
+// identity is checked with reflect: pointer-like clients (the common case)
+// compare by pointer, and any other comparable client type falls back to ==;
+// a client whose dynamic type isn't comparable (e.g. a struct value with a
+// map field) reports false rather than risk a panic comparing it directly.
+func (f *BucketFS) SameBackend(other ocflfs.FS) bool {
+	o, ok := other.(*BucketFS)
+	if !ok || o.bucket != f.bucket {
+		return false
+	}
+	return sameClient(f.client, o.client)
+}
+
+func sameClient(a, b S3API) bool {
+	va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
+	if !va.IsValid() || !vb.IsValid() || va.Type() != vb.Type() {
+		return false
+	}
+	switch va.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		return va.Pointer() == vb.Pointer()
+	}
+	if va.Comparable() {
+		return va.Interface() == vb.Interface()
+	}
+	return false
 }
 
 func (f *BucketFS) WalkFiles(ctx context.Context, dir string) iter.Seq2[*ocflfs.FileRef, error] {

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -40,6 +40,7 @@ var (
 	_ ocflfs.CopyFS       = (*s3.BucketFS)(nil)
 	_ ocflfs.WriteFS      = (*s3.BucketFS)(nil)
 	_ ocflfs.FileWalker   = (*s3.BucketFS)(nil)
+	_ ocflfs.SameBackend  = (*s3.BucketFS)(nil)
 
 	fixtures = filepath.Join("..", "..", "testdata", "content-fixture")
 )
@@ -625,6 +626,123 @@ func TestCopy_Mock(t *testing.T) {
 		})
 	}
 }
+
+func TestSameBackend_Mock(t *testing.T) {
+	client1 := mock.New(bucket)
+	client2 := mock.New(bucket)
+	type testCase struct {
+		desc   string
+		fsys   *s3.BucketFS
+		other  ocflfs.FS
+		expect bool
+	}
+	cases := []testCase{
+		{
+			desc:   "same bucket and client",
+			fsys:   s3.NewBucketFS(client1, bucket),
+			other:  s3.NewBucketFS(client1, bucket),
+			expect: true,
+		}, {
+			desc:   "different bucket",
+			fsys:   s3.NewBucketFS(client1, bucket),
+			other:  s3.NewBucketFS(client1, "other-bucket"),
+			expect: false,
+		}, {
+			desc:   "different client",
+			fsys:   s3.NewBucketFS(client1, bucket),
+			other:  s3.NewBucketFS(client2, bucket),
+			expect: false,
+		}, {
+			desc:   "not a *BucketFS",
+			fsys:   s3.NewBucketFS(client1, bucket),
+			other:  ocflfs.DirFS(t.TempDir()),
+			expect: false,
+		}, {
+			// The client is caller-supplied and can itself be non-comparable
+			// (a struct value carrying a map, say). SameBackend must guard
+			// against that rather than reproduce the dstFS == srcFS panic one
+			// level down.
+			desc:   "non-comparable client",
+			fsys:   s3.NewBucketFS(stubClient{m: map[string]string{}}, bucket),
+			other:  s3.NewBucketFS(stubClient{m: map[string]string{}}, bucket),
+			expect: false,
+		},
+	}
+	for _, tcase := range cases {
+		t.Run(tcase.desc, func(t *testing.T) {
+			be.Equal(t, tcase.expect, tcase.fsys.SameBackend(tcase.other))
+		})
+	}
+}
+
+func TestCopyDispatch_Mock(t *testing.T) {
+	ctx := context.Background()
+	api := mock.New(bucket, &mock.Object{Key: "src-file", Body: []byte("some content")})
+	// Two separately constructed *BucketFS values over the same bucket and
+	// client are the same backend: ocflfs.Copy should take the server-side
+	// fast path (one CopyObject), not a GetObject/PutObject round trip.
+	dstFS := s3.NewBucketFS(api, bucket)
+	srcFS := s3.NewBucketFS(api, bucket)
+	_, err := ocflfs.Copy(ctx, dstFS, "dst-file", srcFS, "src-file")
+	be.NilErr(t, err)
+	be.Equal(t, 1, api.CallCount("CopyObject"))
+	be.Equal(t, 0, api.CallCount("GetObject"))
+	be.Equal(t, 0, api.CallCount("PutObject"))
+}
+
+// stubClient is a minimal s3.S3API implementation whose dynamic type carries
+// a map field, so it is not comparable with ==. It's never actually called:
+// it exists only to exercise BucketFS.SameBackend's guard against a
+// non-comparable client.
+type stubClient struct {
+	m map[string]string
+}
+
+func (stubClient) HeadObject(context.Context, *s3v2.HeadObjectInput, ...func(*s3v2.Options)) (*s3v2.HeadObjectOutput, error) {
+	return nil, nil
+}
+
+func (stubClient) GetObject(context.Context, *s3v2.GetObjectInput, ...func(*s3v2.Options)) (*s3v2.GetObjectOutput, error) {
+	return nil, nil
+}
+
+func (stubClient) ListObjectsV2(context.Context, *s3v2.ListObjectsV2Input, ...func(*s3v2.Options)) (*s3v2.ListObjectsV2Output, error) {
+	return nil, nil
+}
+
+func (stubClient) PutObject(context.Context, *s3v2.PutObjectInput, ...func(*s3v2.Options)) (*s3v2.PutObjectOutput, error) {
+	return nil, nil
+}
+
+func (stubClient) UploadPart(context.Context, *s3v2.UploadPartInput, ...func(*s3v2.Options)) (*s3v2.UploadPartOutput, error) {
+	return nil, nil
+}
+
+func (stubClient) CreateMultipartUpload(context.Context, *s3v2.CreateMultipartUploadInput, ...func(*s3v2.Options)) (*s3v2.CreateMultipartUploadOutput, error) {
+	return nil, nil
+}
+
+func (stubClient) CompleteMultipartUpload(context.Context, *s3v2.CompleteMultipartUploadInput, ...func(*s3v2.Options)) (*s3v2.CompleteMultipartUploadOutput, error) {
+	return nil, nil
+}
+
+func (stubClient) AbortMultipartUpload(context.Context, *s3v2.AbortMultipartUploadInput, ...func(*s3v2.Options)) (*s3v2.AbortMultipartUploadOutput, error) {
+	return nil, nil
+}
+
+func (stubClient) UploadPartCopy(context.Context, *s3v2.UploadPartCopyInput, ...func(*s3v2.Options)) (*s3v2.UploadPartCopyOutput, error) {
+	return nil, nil
+}
+
+func (stubClient) CopyObject(context.Context, *s3v2.CopyObjectInput, ...func(*s3v2.Options)) (*s3v2.CopyObjectOutput, error) {
+	return nil, nil
+}
+
+func (stubClient) DeleteObject(context.Context, *s3v2.DeleteObjectInput, ...func(*s3v2.Options)) (*s3v2.DeleteObjectOutput, error) {
+	return nil, nil
+}
+
+var _ s3.S3API = stubClient{}
 
 func TestWalkFiles_Mock(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
Stacked on #179.

## Summary

`fs.Copy` compared `dstFS == srcFS` to decide whether to use a `CopyFS`'s server-side `Copy` method. That produced false negatives (two distinct `*BucketFS` values over the same bucket/client never matched) and could panic outright when both values shared a non-comparable dynamic type.

- Add an optional `SameBackend` interface FS implementations can use to report backend identity, and have `Copy` consult it on `dstFS` instead of comparing interface values directly.
- Implement `SameBackend` for `s3.BucketFS`: bucket name plus a reflect-guarded client comparison, so a non-comparable client can't reproduce the panic one level down.
- Implement `SameBackend` for `local.FS` as a one-liner (same absolute root path).

Fixes #174 (and settles #125, per that issue's note: whichever design wins between them, one issue closes).

## Test plan

- `fs/fs_test.go` (new): `Copy` dispatch tests — same-backend, different-backend, no-`SameBackend`, and a reproduction of the original panic with a non-comparable dynamic type.
- `fs/s3/fs_test.go`: `TestSameBackend_Mock` (including the non-comparable-client guard) and `TestCopyDispatch_Mock`, which asserts the s3 fast path via `mock.Calls()` (one `CopyObject`, zero `GetObject`/`PutObject`).
- `go build ./...`, `go vet ./...`, `go test ./... -count=5 -race` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYi6TPX3Ja27EoxT3Gngeb)_