### PR TITLE
fs: make RemoveAll(".") a uniform WriteFS contract

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -74,26 +74,20 @@ type WriteFS interface {
 	// Remove the directory with path name and all its contents. If the path
 	// does not exist, return nil.
 	//
-	// Whether name "." empties the storage root or is refused is left to the
-	// implementation: a backend whose root must survive (a filesystem
-	// directory) returns an error, while a backend whose root is a namespace
-	// (an S3 bucket) may empty it. Note the package-level RemoveAll handles
-	// "." itself and never reaches this method for that name, so callers
-	// after uniform root-emptying behavior should use it instead: it is
-	// best-effort, attempting every top-level entry and joining their
-	// errors, so a failure part-way through can still leave a partial
-	// deletion behind.
+	// Removal is best-effort: every entry is attempted even after an earlier
+	// one fails, so a failure can leave a partial deletion behind. The
+	// returned error reports the failures the implementation can see --
+	// joined with errors.Join where it walks the entries itself, and a
+	// single error where it delegates to a backend call that reports only
+	// one of them.
+	//
+	// Name "." empties the storage root: every entry in the top-level
+	// directory is removed and the root itself survives. The root is a
+	// container on every backend -- a filesystem directory, an S3 bucket --
+	// and not something a caller can delete through this interface. Note
+	// this is the one name Remove refuses outright, since "." never names a
+	// file.
 	RemoveAll(ctx context.Context, name string) error
-}
-
-// RootRemover is an optional interface for a [WriteFS] whose backend can
-// empty its storage root in a single operation, without listing and removing
-// entries one at a time. The package-level RemoveAll uses it for name "."
-// when present.
-type RootRemover interface {
-	// RemoveRoot removes the entire contents of the top-level directory
-	// without removing the directory itself. Idempotent, like RemoveAll.
-	RemoveRoot(ctx context.Context) error
 }
 
 // CopyFS is a storage backend that supports copying files.
@@ -201,47 +195,16 @@ func Remove(ctx context.Context, fsys FS, name string) error {
 }
 
 // RemoveAll checks if fsys implements WriteFS and calls its RemoveAll method.
-// It returns ErrOpUnsupported if fsys is not a WriteFS. As a special case, if
-// name == ".", RemoveAll empties the top-level directory itself: if fsys
-// implements [RootRemover], its RemoveRoot method is called and its error
-// returned as-is; otherwise RemoveAll reads the contents of the top-level
-// directory and calls Remove/RemoveAll for every entry, on a best-effort
-// basis -- every entry is attempted even if an earlier one fails, and any
-// errors are joined with errors.Join. That case is handled here, not by the
-// backend, so the backend's own RemoveAll(".") behavior -- refuse or empty,
-// both allowed by WriteFS -- is only observable by calling it directly.
+// It returns ErrOpUnsupported if fsys is not a WriteFS. Every name is passed
+// through, "." included: emptying the storage root is part of the
+// [WriteFS.RemoveAll] contract, which also documents the best-effort removal
+// and error-joining every backend provides.
 func RemoveAll(ctx context.Context, fsys FS, name string) error {
 	writeFS, ok := fsys.(WriteFS)
 	if !ok {
 		return &fs.PathError{Op: "remove_all", Path: name, Err: ErrOpUnsupported}
 	}
-	if name != "." {
-		return writeFS.RemoveAll(ctx, name)
-	}
-	if remover, ok := fsys.(RootRemover); ok {
-		return remover.RemoveRoot(ctx)
-	}
-	var errs error
-	for entry, err := range DirEntries(ctx, fsys, ".") {
-		if entry == nil && err == nil {
-			continue
-		}
-		if err != nil {
-			errs = errors.Join(errs, err)
-			continue
-		}
-		var removeFn func(context.Context, FS, string) error
-		switch {
-		case entry.IsDir():
-			removeFn = RemoveAll
-		default:
-			removeFn = Remove
-		}
-		if err := removeFn(ctx, fsys, entry.Name()); err != nil {
-			errs = errors.Join(errs, err)
-		}
-	}
-	return errs
+	return writeFS.RemoveAll(ctx, name)
 }
 
 // Write checks if fsys implements WriteFS and calls its Write method. It

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -79,8 +79,21 @@ type WriteFS interface {
 	// directory) returns an error, while a backend whose root is a namespace
 	// (an S3 bucket) may empty it. Note the package-level RemoveAll handles
 	// "." itself and never reaches this method for that name, so callers
-	// after uniform root-emptying behavior should use it instead.
+	// after uniform root-emptying behavior should use it instead: it is
+	// best-effort, attempting every top-level entry and joining their
+	// errors, so a failure part-way through can still leave a partial
+	// deletion behind.
 	RemoveAll(ctx context.Context, name string) error
+}
+
+// RootRemover is an optional interface for a [WriteFS] whose backend can
+// empty its storage root in a single operation, without listing and removing
+// entries one at a time. The package-level RemoveAll uses it for name "."
+// when present.
+type RootRemover interface {
+	// RemoveRoot removes the entire contents of the top-level directory
+	// without removing the directory itself. Idempotent, like RemoveAll.
+	RemoveRoot(ctx context.Context) error
 }
 
 // CopyFS is a storage backend that supports copying files.
@@ -189,11 +202,14 @@ func Remove(ctx context.Context, fsys FS, name string) error {
 
 // RemoveAll checks if fsys implements WriteFS and calls its RemoveAll method.
 // It returns ErrOpUnsupported if fsys is not a WriteFS. As a special case, if
-// name == ".", RemoveAll reads the contents of the top-level directory and
-// calls Remove/RemoveAll for all entries. That case is handled here, not by
-// the backend, so the backend's own RemoveAll(".") behavior -- refuse or
-// empty, both allowed by WriteFS -- is only observable by calling it
-// directly.
+// name == ".", RemoveAll empties the top-level directory itself: if fsys
+// implements [RootRemover], its RemoveRoot method is called and its error
+// returned as-is; otherwise RemoveAll reads the contents of the top-level
+// directory and calls Remove/RemoveAll for every entry, on a best-effort
+// basis -- every entry is attempted even if an earlier one fails, and any
+// errors are joined with errors.Join. That case is handled here, not by the
+// backend, so the backend's own RemoveAll(".") behavior -- refuse or empty,
+// both allowed by WriteFS -- is only observable by calling it directly.
 func RemoveAll(ctx context.Context, fsys FS, name string) error {
 	writeFS, ok := fsys.(WriteFS)
 	if !ok {
@@ -202,9 +218,17 @@ func RemoveAll(ctx context.Context, fsys FS, name string) error {
 	if name != "." {
 		return writeFS.RemoveAll(ctx, name)
 	}
+	if remover, ok := fsys.(RootRemover); ok {
+		return remover.RemoveRoot(ctx)
+	}
+	var errs error
 	for entry, err := range DirEntries(ctx, fsys, ".") {
+		if entry == nil && err == nil {
+			continue
+		}
 		if err != nil {
-			return err
+			errs = errors.Join(errs, err)
+			continue
 		}
 		var removeFn func(context.Context, FS, string) error
 		switch {
@@ -214,10 +238,10 @@ func RemoveAll(ctx context.Context, fsys FS, name string) error {
 			removeFn = Remove
 		}
 		if err := removeFn(ctx, fsys, entry.Name()); err != nil {
-			return err
+			errs = errors.Join(errs, err)
 		}
 	}
-	return nil
+	return errs
 }
 
 // Write checks if fsys implements WriteFS and calls its Write method. It

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -3,8 +3,10 @@ package fs_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"io/fs"
+	"iter"
 	"testing"
 
 	"github.com/carlmjohnson/be"
@@ -135,4 +137,152 @@ func TestCopyDispatch_NonComparableDynamicType(t *testing.T) {
 	// it does not panic getting there.
 	_, err := ocflfs.Copy(ctx, fsys, "dst", fsys, "src")
 	be.NilErr(t, err)
+}
+
+// stubDirEntry is a minimal fs.DirEntry for exercising the RemoveAll(".")
+// loop without a real backend.
+type stubDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (e *stubDirEntry) Name() string { return e.name }
+func (e *stubDirEntry) IsDir() bool  { return e.isDir }
+func (e *stubDirEntry) Type() fs.FileMode {
+	if e.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+func (e *stubDirEntry) Info() (fs.FileInfo, error) { return nil, fs.ErrInvalid }
+
+// rootStubFS is a WriteFS/DirEntriesFS spy whose root entries and per-name
+// removal errors are configured directly, used to exercise the
+// package-level RemoveAll(".") loop.
+type rootStubFS struct {
+	entries    []fs.DirEntry
+	entriesErr error // if set, yielded after entries, with a nil entry
+	yieldNil   bool  // if true, also yield a (nil, nil) pair before entriesErr/entries end
+
+	removeErr map[string]error // per-name error returned by Remove/RemoveAll
+
+	removed []string // names actually passed to Remove/RemoveAll, in order
+}
+
+func (r *rootStubFS) OpenFile(context.Context, string) (fs.File, error) { return nil, fs.ErrNotExist }
+
+func (r *rootStubFS) DirEntries(_ context.Context, _ string) iter.Seq2[fs.DirEntry, error] {
+	return func(yield func(fs.DirEntry, error) bool) {
+		if r.yieldNil {
+			if !yield(nil, nil) {
+				return
+			}
+		}
+		for _, e := range r.entries {
+			if !yield(e, nil) {
+				return
+			}
+		}
+		if r.entriesErr != nil {
+			yield(nil, r.entriesErr)
+		}
+	}
+}
+
+func (r *rootStubFS) Write(context.Context, string, io.Reader) (int64, error) {
+	return 0, fs.ErrInvalid
+}
+
+func (r *rootStubFS) Remove(_ context.Context, name string) error {
+	r.removed = append(r.removed, name)
+	return r.removeErr[name]
+}
+
+func (r *rootStubFS) RemoveAll(_ context.Context, name string) error {
+	r.removed = append(r.removed, name)
+	return r.removeErr[name]
+}
+
+var (
+	_ ocflfs.FS           = (*rootStubFS)(nil)
+	_ ocflfs.WriteFS      = (*rootStubFS)(nil)
+	_ ocflfs.DirEntriesFS = (*rootStubFS)(nil)
+)
+
+func TestRemoveAllDot(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("attempts every sibling and joins the errors", func(t *testing.T) {
+		boom := errors.New("boom")
+		fsys := &rootStubFS{
+			entries: []fs.DirEntry{
+				&stubDirEntry{name: "adir", isDir: true},
+				&stubDirEntry{name: "boom.txt"},
+				&stubDirEntry{name: "keep.txt"},
+			},
+			removeErr: map[string]error{"boom.txt": boom},
+		}
+		err := ocflfs.RemoveAll(ctx, fsys, ".")
+		be.True(t, err != nil)
+		be.True(t, errors.Is(err, boom))
+		// Every sibling must have been attempted, not just the ones before
+		// the failure.
+		be.AllEqual(t, []string{"adir", "boom.txt", "keep.txt"}, fsys.removed)
+	})
+
+	t.Run("skips a nil entry paired with a nil error without panicking", func(t *testing.T) {
+		fsys := &rootStubFS{
+			yieldNil: true,
+			entries:  []fs.DirEntry{&stubDirEntry{name: "keep.txt"}},
+		}
+		err := ocflfs.RemoveAll(ctx, fsys, ".")
+		be.NilErr(t, err)
+		be.AllEqual(t, []string{"keep.txt"}, fsys.removed)
+	})
+
+	t.Run("joins a DirEntries iteration error with per-entry errors", func(t *testing.T) {
+		boom := errors.New("boom")
+		iterErr := errors.New("iteration failed")
+		fsys := &rootStubFS{
+			entries:    []fs.DirEntry{&stubDirEntry{name: "boom.txt"}},
+			removeErr:  map[string]error{"boom.txt": boom},
+			entriesErr: iterErr,
+		}
+		err := ocflfs.RemoveAll(ctx, fsys, ".")
+		be.True(t, errors.Is(err, boom))
+		be.True(t, errors.Is(err, iterErr))
+	})
+}
+
+// rootRemoverStubFS is a WriteFS additionally implementing RootRemover, used
+// to assert that the package-level RemoveAll(".") prefers RemoveRoot and
+// never falls back to a per-entry loop.
+type rootRemoverStubFS struct {
+	rootStubFS
+	removeRootCalls int
+	removeRootErr   error
+}
+
+func (r *rootRemoverStubFS) RemoveRoot(context.Context) error {
+	r.removeRootCalls++
+	return r.removeRootErr
+}
+
+var _ ocflfs.RootRemover = (*rootRemoverStubFS)(nil)
+
+func TestRemoveAllDot_PrefersRootRemover(t *testing.T) {
+	ctx := context.Background()
+	boom := errors.New("boom")
+	fsys := &rootRemoverStubFS{
+		rootStubFS: rootStubFS{
+			entries: []fs.DirEntry{&stubDirEntry{name: "boom.txt"}},
+		},
+		removeRootErr: boom,
+	}
+	err := ocflfs.RemoveAll(ctx, fsys, ".")
+	// The error is returned exactly as RemoveRoot reported it.
+	be.True(t, errors.Is(err, boom))
+	be.Equal(t, 1, fsys.removeRootCalls)
+	// No per-entry fallback: DirEntries/Remove is never consulted.
+	be.Equal(t, 0, len(fsys.removed))
 }

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -139,8 +139,43 @@ func TestCopyDispatch_NonComparableDynamicType(t *testing.T) {
 	be.NilErr(t, err)
 }
 
-// stubDirEntry is a minimal fs.DirEntry for exercising the RemoveAll(".")
-// loop without a real backend.
+// recordingWriteFS records the names passed to Remove and RemoveAll. It also
+// implements DirEntriesFS, yielding an entry that must never be removed: the
+// package-level RemoveAll used to list the root and remove entries one by one
+// for name ".", and this is what catches a return to that.
+type recordingWriteFS struct {
+	removeAllNames []string
+	removeNames    []string
+	dirEntriesFor  []string
+}
+
+func (r *recordingWriteFS) OpenFile(context.Context, string) (fs.File, error) {
+	return nil, fs.ErrNotExist
+}
+
+func (r *recordingWriteFS) Write(context.Context, string, io.Reader) (int64, error) {
+	return 0, fs.ErrInvalid
+}
+
+func (r *recordingWriteFS) Remove(_ context.Context, name string) error {
+	r.removeNames = append(r.removeNames, name)
+	return nil
+}
+
+func (r *recordingWriteFS) RemoveAll(_ context.Context, name string) error {
+	r.removeAllNames = append(r.removeAllNames, name)
+	return nil
+}
+
+func (r *recordingWriteFS) DirEntries(_ context.Context, name string) iter.Seq2[fs.DirEntry, error] {
+	r.dirEntriesFor = append(r.dirEntriesFor, name)
+	return func(yield func(fs.DirEntry, error) bool) {
+		yield(&stubDirEntry{name: "must-not-be-removed.txt"}, nil)
+	}
+}
+
+// stubDirEntry is a minimal fs.DirEntry, enough for recordingWriteFS to yield
+// something from DirEntries.
 type stubDirEntry struct {
 	name  string
 	isDir bool
@@ -156,133 +191,33 @@ func (e *stubDirEntry) Type() fs.FileMode {
 }
 func (e *stubDirEntry) Info() (fs.FileInfo, error) { return nil, fs.ErrInvalid }
 
-// rootStubFS is a WriteFS/DirEntriesFS spy whose root entries and per-name
-// removal errors are configured directly, used to exercise the
-// package-level RemoveAll(".") loop.
-type rootStubFS struct {
-	entries    []fs.DirEntry
-	entriesErr error // if set, yielded after entries, with a nil entry
-	yieldNil   bool  // if true, also yield a (nil, nil) pair before entriesErr/entries end
-
-	removeErr map[string]error // per-name error returned by Remove/RemoveAll
-
-	removed []string // names actually passed to Remove/RemoveAll, in order
-}
-
-func (r *rootStubFS) OpenFile(context.Context, string) (fs.File, error) { return nil, fs.ErrNotExist }
-
-func (r *rootStubFS) DirEntries(_ context.Context, _ string) iter.Seq2[fs.DirEntry, error] {
-	return func(yield func(fs.DirEntry, error) bool) {
-		if r.yieldNil {
-			if !yield(nil, nil) {
-				return
-			}
-		}
-		for _, e := range r.entries {
-			if !yield(e, nil) {
-				return
-			}
-		}
-		if r.entriesErr != nil {
-			yield(nil, r.entriesErr)
-		}
-	}
-}
-
-func (r *rootStubFS) Write(context.Context, string, io.Reader) (int64, error) {
-	return 0, fs.ErrInvalid
-}
-
-func (r *rootStubFS) Remove(_ context.Context, name string) error {
-	r.removed = append(r.removed, name)
-	return r.removeErr[name]
-}
-
-func (r *rootStubFS) RemoveAll(_ context.Context, name string) error {
-	r.removed = append(r.removed, name)
-	return r.removeErr[name]
-}
-
 var (
-	_ ocflfs.FS           = (*rootStubFS)(nil)
-	_ ocflfs.WriteFS      = (*rootStubFS)(nil)
-	_ ocflfs.DirEntriesFS = (*rootStubFS)(nil)
+	_ ocflfs.FS           = (*recordingWriteFS)(nil)
+	_ ocflfs.WriteFS      = (*recordingWriteFS)(nil)
+	_ ocflfs.DirEntriesFS = (*recordingWriteFS)(nil)
 )
 
-func TestRemoveAllDot(t *testing.T) {
+func TestRemoveAllDelegates(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("attempts every sibling and joins the errors", func(t *testing.T) {
-		boom := errors.New("boom")
-		fsys := &rootStubFS{
-			entries: []fs.DirEntry{
-				&stubDirEntry{name: "adir", isDir: true},
-				&stubDirEntry{name: "boom.txt"},
-				&stubDirEntry{name: "keep.txt"},
-			},
-			removeErr: map[string]error{"boom.txt": boom},
-		}
-		err := ocflfs.RemoveAll(ctx, fsys, ".")
-		be.True(t, err != nil)
-		be.True(t, errors.Is(err, boom))
-		// Every sibling must have been attempted, not just the ones before
-		// the failure.
-		be.AllEqual(t, []string{"adir", "boom.txt", "keep.txt"}, fsys.removed)
-	})
-
-	t.Run("skips a nil entry paired with a nil error without panicking", func(t *testing.T) {
-		fsys := &rootStubFS{
-			yieldNil: true,
-			entries:  []fs.DirEntry{&stubDirEntry{name: "keep.txt"}},
-		}
-		err := ocflfs.RemoveAll(ctx, fsys, ".")
-		be.NilErr(t, err)
-		be.AllEqual(t, []string{"keep.txt"}, fsys.removed)
-	})
-
-	t.Run("joins a DirEntries iteration error with per-entry errors", func(t *testing.T) {
-		boom := errors.New("boom")
-		iterErr := errors.New("iteration failed")
-		fsys := &rootStubFS{
-			entries:    []fs.DirEntry{&stubDirEntry{name: "boom.txt"}},
-			removeErr:  map[string]error{"boom.txt": boom},
-			entriesErr: iterErr,
-		}
-		err := ocflfs.RemoveAll(ctx, fsys, ".")
-		be.True(t, errors.Is(err, boom))
-		be.True(t, errors.Is(err, iterErr))
-	})
-}
-
-// rootRemoverStubFS is a WriteFS additionally implementing RootRemover, used
-// to assert that the package-level RemoveAll(".") prefers RemoveRoot and
-// never falls back to a per-entry loop.
-type rootRemoverStubFS struct {
-	rootStubFS
-	removeRootCalls int
-	removeRootErr   error
-}
-
-func (r *rootRemoverStubFS) RemoveRoot(context.Context) error {
-	r.removeRootCalls++
-	return r.removeRootErr
-}
-
-var _ ocflfs.RootRemover = (*rootRemoverStubFS)(nil)
-
-func TestRemoveAllDot_PrefersRootRemover(t *testing.T) {
-	ctx := context.Background()
-	boom := errors.New("boom")
-	fsys := &rootRemoverStubFS{
-		rootStubFS: rootStubFS{
-			entries: []fs.DirEntry{&stubDirEntry{name: "boom.txt"}},
-		},
-		removeRootErr: boom,
+	// "." is the interesting name: emptying the storage root is the
+	// backend's job now, so the helper must hand it over untouched rather
+	// than listing the root and removing entries itself.
+	for _, name := range []string{".", "some/dir"} {
+		t.Run(name, func(t *testing.T) {
+			fsys := &recordingWriteFS{}
+			be.NilErr(t, ocflfs.RemoveAll(ctx, fsys, name))
+			be.AllEqual(t, []string{name}, fsys.removeAllNames)
+			be.Equal(t, 0, len(fsys.removeNames))
+			be.Equal(t, 0, len(fsys.dirEntriesFor))
+		})
 	}
-	err := ocflfs.RemoveAll(ctx, fsys, ".")
-	// The error is returned exactly as RemoveRoot reported it.
-	be.True(t, errors.Is(err, boom))
-	be.Equal(t, 1, fsys.removeRootCalls)
-	// No per-entry fallback: DirEntries/Remove is never consulted.
-	be.Equal(t, 0, len(fsys.removed))
+}
+
+func TestRemoveAllNotAWriteFS(t *testing.T) {
+	err := ocflfs.RemoveAll(context.Background(), &spySrcFS{}, ".")
+	be.True(t, errors.Is(err, ocflfs.ErrOpUnsupported))
+	var pathErr *fs.PathError
+	be.True(t, errors.As(err, &pathErr))
+	be.Equal(t, ".", pathErr.Path)
 }

--- a/fs/internal/imptest/imptest.go
+++ b/fs/internal/imptest/imptest.go
@@ -29,12 +29,13 @@
 // An entry point takes an options struct only when the suite genuinely cannot
 // assert something for every backend at once. That is a high bar, and most do
 // not clear it: [TestDirEntries], [TestWriteFSWrite] and [TestWriteFSRemove]
-// take no struct at all. [WriteFSRemoveAll] holds the only real knobs,
-// because the backends differ there in capability rather than in wording — s3
-// can empty its bucket and local cannot remove its own root. The ErrWalk
-// field on [WalkFiles] is a fixture rather than a knob: it supplies a backend
-// whose walk fails, and the assertions made about that failure are the same
-// either way.
+// take no struct at all. [WriteFSRemoveAll] holds the only real knob,
+// RemoveAllOnFileRemovesIt, because the backends differ there in capability
+// rather than in wording: RemoveAll on a file's own path deletes it on a
+// hierarchical backend and does not on a key-value one, where a key is not
+// under its own prefix. The ErrWalk field on [WalkFiles] is a fixture rather
+// than a knob: it supplies a backend whose walk fails, and the assertions
+// made about that failure are the same either way.
 //
 // Before adding a knob, check which of the two it is. A field that lets each
 // backend name a different error is usually recording a defect, not a

--- a/fs/internal/imptest/writefs.go
+++ b/fs/internal/imptest/writefs.go
@@ -234,14 +234,6 @@ func TestWriteFSRemove(t *testing.T, fsys ocflfs.WriteFS) {
 // WriteFSRemoveAll configures [TestWriteFSRemoveAll] with the parts of
 // RemoveAll that are left to the implementation.
 type WriteFSRemoveAll struct {
-	// RemoveAllDotIsError reports whether the backend's own
-	// RemoveAll(ctx, ".") refuses rather than emptying the top-level
-	// directory. This genuinely differs between correct implementations: the
-	// local backend refuses because its storage root must survive, the S3
-	// backend empties the bucket. Callers who want uniform behavior use the
-	// package-level [ocflfs.RemoveAll], which is covered separately.
-	RemoveAllDotIsError bool
-
 	// RemoveAllOnFileRemovesIt reports whether RemoveAll applied directly to
 	// a file path removes that file. A hierarchical backend deletes it
 	// (os.RemoveAll does); a backend that treats the name as a key prefix
@@ -364,22 +356,43 @@ func TestWriteFSRemoveAll(t *testing.T, fsys ocflfs.WriteFS, opts WriteFSRemoveA
 		be.Equal(t, !opts.RemoveAllOnFileRemovesIt, exists(t, name))
 	})
 
-	// Runs last: on a backend that empties its root, this subtest removes
-	// everything the ones above wrote.
+	// Runs last: this subtest removes everything the ones above wrote.
 	t.Run("dot", func(t *testing.T) {
-		const probe = "imptest-removeall/dot-probe.txt"
+		// "." empties the storage root on every backend. The two families
+		// reach it differently -- one walks a directory it must not delete,
+		// the other lists a bucket with no prefix -- and used to disagree
+		// about whether it was allowed at all, which is why the assertions
+		// below pin the result rather than the mechanism.
+		const (
+			probe  = "imptest-removeall/dot-probe.txt"
+			nested = "imptest-removeall/deeper/nested.txt"
+			toplvl = "dot-toplevel.txt"
+		)
 		write(t, probe)
-		err := fsys.RemoveAll(ctx, ".")
-		if opts.RemoveAllDotIsError {
-			// Refusing must be inert: the root is untouched.
-			be.True(t, err != nil)
-			be.True(t, exists(t, probe))
-			return
-		}
+		write(t, nested)
+		write(t, toplvl)
+
 		// Emptying must actually empty, and must not report the now-absent
 		// entries as an error.
-		be.NilErr(t, err)
-		be.False(t, exists(t, probe))
+		be.NilErr(t, fsys.RemoveAll(ctx, "."))
+		for _, name := range []string{probe, nested, toplvl} {
+			if exists(t, name) {
+				t.Errorf("%q survived RemoveAll(\".\")", name)
+			}
+		}
+
+		// The root itself survives: it is the container, not an entry in
+		// it. A backend that deletes its own root passes every assertion
+		// above and fails here -- on the local backend that also
+		// invalidates the handle every other method resolves through.
+		const after = "imptest-removeall/after-dot.txt"
+		write(t, after)
+		be.True(t, exists(t, after))
+
+		// Idempotent, like RemoveAll for any other name.
+		be.NilErr(t, fsys.RemoveAll(ctx, "."))
+		be.False(t, exists(t, after))
+		be.NilErr(t, fsys.RemoveAll(ctx, "."))
 	})
 }
 

--- a/fs/local/imptest_test.go
+++ b/fs/local/imptest_test.go
@@ -40,7 +40,6 @@ func TestWriteFSRemove_Local(t *testing.T) {
 // removes a file addressed directly, matching os.RemoveAll.
 func TestWriteFSRemoveAll_Local(t *testing.T) {
 	imptest.TestWriteFSRemoveAll(t, tmpLocalFS(t), imptest.WriteFSRemoveAll{
-		RemoveAllDotIsError:      true,
 		RemoveAllOnFileRemovesIt: true,
 	})
 }

--- a/fs/local/localfs.go
+++ b/fs/local/localfs.go
@@ -559,22 +559,21 @@ func (fsys *FS) Remove(ctx context.Context, name string) error {
 // inside the storage root, so a symlink in an intermediate component cannot
 // direct the removal at a tree outside it. A symlink at name itself is
 // removed as the link entry it is; the tree it points at is untouched.
+//
+// Name "." empties the storage root without removing the root directory
+// itself, per the [ocflfs.WriteFS] RemoveAll contract.
+//
+// Removal is best-effort either way. Root.RemoveAll already keeps going past
+// an entry it cannot remove, reporting the first failure it hit; emptying the
+// root joins the failures across the top-level entries instead, so one
+// undeletable entry neither hides its siblings nor stops them being
+// attempted.
 func (fsys *FS) RemoveAll(ctx context.Context, name string) error {
 	if !fs.ValidPath(name) {
 		return &fs.PathError{
 			Op:   "remove",
 			Path: name,
 			Err:  fs.ErrInvalid,
-		}
-	}
-	// The guard stays ahead of the Root call: Root.RemoveAll(".") reports a
-	// bare EINVAL that does not satisfy errors.Is(err, fs.ErrInvalid), so the
-	// refusal is spelled out here where callers can match it.
-	if name == "." {
-		return &fs.PathError{
-			Op:   "remove",
-			Path: name,
-			Err:  errors.New("cannot remove top-level directory"),
 		}
 	}
 	if err := ctx.Err(); err != nil {
@@ -584,6 +583,12 @@ func (fsys *FS) RemoveAll(ctx context.Context, name string) error {
 			Err:  err,
 		}
 	}
+	// The branch stays ahead of the Root call: Root.RemoveAll(".") reports a
+	// bare EINVAL, and removing the root directory would invalidate the
+	// os.Root handle every other method resolves through.
+	if name == "." {
+		return fsys.removeRootContents(ctx)
+	}
 	if err := fsys.root.RemoveAll(name); err != nil {
 		return &fs.PathError{
 			Op:   "remove",
@@ -592,6 +597,67 @@ func (fsys *FS) RemoveAll(ctx context.Context, name string) error {
 		}
 	}
 	return nil
+}
+
+// removeRootContents removes every entry in the storage root, leaving the root
+// directory itself in place. Failures are joined rather than returned on the
+// first, so a single undeletable entry does not abandon the rest.
+func (fsys *FS) removeRootContents(ctx context.Context) error {
+	dir, err := fsys.root.Open(".")
+	if err != nil {
+		return &fs.PathError{
+			Op:   "remove",
+			Path: ".",
+			Err:  unwrapPathError(err),
+		}
+	}
+	// The whole listing is read and the handle closed before anything is
+	// removed: holding a directory handle open across the deletion of its
+	// children is harmless on POSIX but can block removal on Windows.
+	entries, readErr := dir.ReadDir(-1)
+	closeErr := dir.Close()
+	// Sorted for the same reason DirEntries sorts: the handle returns
+	// directory order, and a caller reading a joined error should see the
+	// failures in a stable order rather than one that varies by filesystem.
+	slices.SortFunc(entries, func(a, b fs.DirEntry) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
+	var errs error
+	if readErr != nil {
+		// A partial read still names entries worth removing, so the error
+		// is collected and the entries it did yield are attempted.
+		errs = errors.Join(errs, &fs.PathError{
+			Op:   "remove",
+			Path: ".",
+			Err:  unwrapPathError(readErr),
+		})
+	}
+	if closeErr != nil {
+		errs = errors.Join(errs, &fs.PathError{
+			Op:   "remove",
+			Path: ".",
+			Err:  unwrapPathError(closeErr),
+		})
+	}
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(errs, &fs.PathError{
+				Op:   "remove",
+				Path: ".",
+				Err:  err,
+			})
+		}
+		// Path is the entry rather than ".", so a joined error says which
+		// entries failed.
+		if err := fsys.root.RemoveAll(entry.Name()); err != nil {
+			errs = errors.Join(errs, &fs.PathError{
+				Op:   "remove",
+				Path: entry.Name(),
+				Err:  unwrapPathError(err),
+			})
+		}
+	}
+	return errs
 }
 
 // unwrapPathError returns the underlying error of a *fs.PathError, so an

--- a/fs/local/localfs_test.go
+++ b/fs/local/localfs_test.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -354,18 +355,69 @@ func TestFS_RemoveAll(t *testing.T) {
 		be.True(t, os.IsNotExist(err))
 	})
 
-	t.Run("prevents removing root directory", func(t *testing.T) {
+	t.Run("empties root directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		fsys, err := NewFS(tmpDir)
 		be.NilErr(t, err)
 
 		ctx := context.Background()
+		_, err = fsys.Write(ctx, "top.txt", strings.NewReader("top"))
+		be.NilErr(t, err)
+		_, err = fsys.Write(ctx, "adir/nested.txt", strings.NewReader("nested"))
+		be.NilErr(t, err)
+
+		be.NilErr(t, fsys.RemoveAll(ctx, "."))
+
+		entries, err := os.ReadDir(tmpDir)
+		be.NilErr(t, err)
+		be.Equal(t, 0, len(entries))
+
+		// The root directory itself survives -- it is the container, not an
+		// entry in it, and the FS's os.Root handle resolves every other
+		// method through it.
+		info, err := os.Stat(tmpDir)
+		be.NilErr(t, err)
+		be.True(t, info.IsDir())
+		_, err = fsys.Write(ctx, "after.txt", strings.NewReader("after"))
+		be.NilErr(t, err)
+	})
+
+	t.Run("emptying root is best-effort", func(t *testing.T) {
+		// One undeletable entry must not abandon its siblings. The entry is
+		// made undeletable by clearing write permission on the directory
+		// holding it, which only works where the permission bits are
+		// actually enforced against this process.
+		if runtime.GOOS == "windows" {
+			t.Skip("directory permissions do not block removal on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("running as root: permission bits do not block removal")
+		}
+		tmpDir := t.TempDir()
+		fsys, err := NewFS(tmpDir)
+		be.NilErr(t, err)
+
+		ctx := context.Background()
+		_, err = fsys.Write(ctx, "adir/inner.txt", strings.NewReader("inner"))
+		be.NilErr(t, err)
+		_, err = fsys.Write(ctx, "keep.txt", strings.NewReader("keep"))
+		be.NilErr(t, err)
+
+		blocked := filepath.Join(tmpDir, "adir")
+		be.NilErr(t, os.Chmod(blocked, 0500))
+		t.Cleanup(func() { _ = os.Chmod(blocked, 0755) })
+
 		err = fsys.RemoveAll(ctx, ".")
 		be.True(t, err != nil)
-
+		// The failure names the entry that failed, not just ".", so a
+		// joined error says which entries are left behind.
 		var pathErr *fs.PathError
 		be.True(t, errors.As(err, &pathErr))
-		be.Equal(t, ".", pathErr.Path)
+		be.Equal(t, "adir", pathErr.Path)
+
+		// The sibling after the failure was still attempted, and removed.
+		_, err = os.Stat(filepath.Join(tmpDir, "keep.txt"))
+		be.True(t, os.IsNotExist(err))
 	})
 
 	t.Run("succeeds on non-existent path", func(t *testing.T) {

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"iter"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1089,4 +1090,94 @@ func (s *seekerReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 		return 0, err
 	}
 	return s.rs.Read(p)
+}
+
+// failDeleteAPI is the mock with DeleteObject made to fail for one chosen key.
+// The mock records calls but injects no errors, and does not need to: the
+// method set it satisfies is an interface, so shadowing one method on an
+// embedding type is enough to stand in for the whole thing.
+type failDeleteAPI struct {
+	*mock.S3API
+	failKey string
+	err     error
+	// attempted records every key DeleteObject was called with. The mock's
+	// own call log cannot serve here: the failing key never reaches it.
+	attempted []string
+}
+
+func (a *failDeleteAPI) DeleteObject(ctx context.Context, in *s3v2.DeleteObjectInput,
+	opts ...func(*s3v2.Options)) (*s3v2.DeleteObjectOutput, error) {
+	if in.Key != nil {
+		a.attempted = append(a.attempted, *in.Key)
+	}
+	if in.Key != nil && *in.Key == a.failKey {
+		return nil, a.err
+	}
+	return a.S3API.DeleteObject(ctx, in, opts...)
+}
+
+// TestRemoveAllBestEffort pins the WriteFS.RemoveAll contract that one key
+// which will not delete must not abandon the keys after it. The subtree case
+// is the one this changed: removeAll used to return on the first failing
+// DeleteObject, leaving every later key in place and reporting only that one
+// failure.
+func TestRemoveAllBestEffort(t *testing.T) {
+	ctx := context.Background()
+	boom := errors.New("boom")
+
+	// Keys are chosen so the failing one sorts in the middle: a listing is
+	// returned in key order, so a survivor after it is what proves the loop
+	// kept going.
+	for _, tc := range []struct {
+		name    string
+		remove  string
+		keys    []string
+		failKey string
+	}{
+		{
+			name:    "dot",
+			remove:  ".",
+			keys:    []string{"a.txt", "b.txt", "c.txt"},
+			failKey: "b.txt",
+		},
+		{
+			name:    "subtree",
+			remove:  "dir",
+			keys:    []string{"dir/a.txt", "dir/b.txt", "dir/c.txt"},
+			failKey: "dir/b.txt",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := make([]*mock.Object, 0, len(tc.keys))
+			for _, key := range tc.keys {
+				objects = append(objects, &mock.Object{Key: key, Body: []byte(key)})
+			}
+			api := &failDeleteAPI{
+				S3API:   mock.New(bucket, objects...),
+				failKey: tc.failKey,
+				err:     boom,
+			}
+			fsys := s3.NewBucketFS(api, bucket)
+
+			err := fsys.RemoveAll(ctx, tc.remove)
+			be.True(t, err != nil)
+			be.True(t, errors.Is(err, boom))
+
+			// Every key was attempted, the failing one included.
+			attempted := slices.Clone(api.attempted)
+			sort.Strings(attempted)
+			be.AllEqual(t, tc.keys, attempted)
+
+			// And every key but the failing one is actually gone.
+			for _, key := range tc.keys {
+				if key == tc.failKey {
+					be.False(t, api.WasDeleted(key))
+					continue
+				}
+				if !api.WasDeleted(key) {
+					t.Errorf("%q was not deleted; RemoveAll(%q) abandoned it", key, tc.remove)
+				}
+			}
+		})
+	}
 }

--- a/fs/s3/imptest_test.go
+++ b/fs/s3/imptest_test.go
@@ -39,7 +39,6 @@ func TestWriteFSRemove_S3(t *testing.T) {
 func TestWriteFSRemoveAll_S3(t *testing.T) {
 	fsys := s3.NewBucketFS(mock.New(bucket), bucket)
 	imptest.TestWriteFSRemoveAll(t, fsys, imptest.WriteFSRemoveAll{
-		RemoveAllDotIsError:      false,
 		RemoveAllOnFileRemovesIt: false,
 	})
 }

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -240,12 +240,22 @@ func removeAll(ctx context.Context, api RemoveAllAPI, buck string, name string) 
 	}
 	params := &s3.ListObjectsV2Input{Bucket: &buck, MaxKeys: &maxKeys}
 	if name != "." {
+		// The trailing separator is what keeps "a" from matching the
+		// sibling key "ab". "." carries no prefix at all: it names the
+		// whole bucket.
 		params.Prefix = aws.String(name + "/")
 	}
+	// Deletion is best-effort, per the WriteFS.RemoveAll contract: one key
+	// that will not delete must not abandon the keys after it, which would
+	// leave a partial deletion and report only the first of possibly many
+	// failures.
+	var errs error
 	for {
 		list, err := api.ListObjectsV2(ctx, params)
 		if err != nil {
-			return pathErr("removeall", name, err)
+			// Without a listing there is nothing further to attempt, so
+			// this one does stop the loop.
+			return errors.Join(errs, pathErr("removeall", name, err))
 		}
 		for _, obj := range list.Contents {
 			_, err := api.DeleteObject(ctx, &s3.DeleteObjectInput{
@@ -253,7 +263,11 @@ func removeAll(ctx context.Context, api RemoveAllAPI, buck string, name string) 
 				Key:    obj.Key,
 			})
 			if err != nil {
-				return pathErr("removeall", name, err)
+				key := name
+				if obj.Key != nil {
+					key = *obj.Key
+				}
+				errs = errors.Join(errs, pathErr("removeall", key, err))
 			}
 		}
 		params.ContinuationToken = list.NextContinuationToken
@@ -261,7 +275,7 @@ func removeAll(ctx context.Context, api RemoveAllAPI, buck string, name string) 
 			break
 		}
 	}
-	return nil
+	return errs
 }
 
 // walkFiles returns an iterator that yields PathInfo for files in the dir


### PR DESCRIPTION
Closes #175.

## The problem

`WriteFS.RemoveAll` left the name `"."` to the implementation, and the two backends took opposite branches:

- **local** (`fs/local/localfs.go`) refused it, returning a `*fs.PathError` wrapping a bare `errors.New("cannot remove top-level directory")` — an error that did not even satisfy `errors.Is(err, fs.ErrInvalid)`.
- **s3** (`fs/s3/s3.go`) dropped the listing prefix and emptied the bucket.

The package-level `ocflfs.RemoveAll` papered over the split by intercepting `"."` and emptying the root itself with a `DirEntries` loop — and that loop returned on the first entry-removal failure, abandoning every sibling after it (the defect #175 reports).

## What changed

**Emptying the root is now part of the interface contract.** `RemoveAll(".")` removes every top-level entry and leaves the root itself in place, on every backend — the root is a container (a filesystem directory, an S3 bucket), not something a caller deletes through this interface. local now empties its root rather than refusing; s3 already did.

**The helper's special case and `RootRemover` are gone.** With the backends agreeing, `ocflfs.RemoveAll` delegates every name straight to the backend. `RootRemover` existed only because the helper could not rely on the backend for `"."`; a backend that can empty its root in one operation now just does that in its own `RemoveAll`, which is what #166 will do with a bulk delete.

**Best-effort removal applies to every name, not only `"."`.** One entry that will not delete must not abandon the entries after it. s3 is where this actually changes behavior: its loop returned on the first failing `DeleteObject`, leaving every later key in place and reporting one of possibly many failures. It now attempts every key and joins the errors. local's `"."` path joins across the top-level entries; its subtree path keeps delegating to `os.Root.RemoveAll`, which already continues past a failure but can only surface the first one — reimplementing it to join would mean hand-rolling the symlink-safe recursion it provides.

`Remove(ctx, ".")` is unaffected and still returns `fs.ErrInvalid` on both backends.

## Callers

No production behavior change. The only in-tree caller that reaches `"."` is `update-plan.go:299` (`Revert` of a v1 object rooted at `"."`, exercised throughout `update-plan_test.go` against a `*local.FS`). It goes through `ocflfs.RemoveAll`, which emptied the root before via the loop and now does so via the backend — same net effect, one fewer indirection.

## Tests

- `imptest` drops the `RemoveAllDotIsError` knob; both backends now run the same `dot` subtest, which also pins that the root survives and is still writable afterwards, and that emptying is idempotent. `RemoveAllOnFileRemovesIt` stays — hierarchical vs. key-prefix removal is a real capability difference.
- s3 gains best-effort coverage for both name shapes via a mock wrapper that fails one key. The subtree case fails against the previous implementation.
- local gains best-effort coverage for `"."` using a directory whose permissions block removal. It is skipped when running as root; it was verified under a dropped uid rather than trusted to the skip.
- Both new best-effort assertions were checked against a deliberately mutated implementation to confirm they fail without the fix.
- `fs/fs_test.go` drops the tests for the removed helper path and keeps one asserting that `"."` is passed through rather than special-cased.

## Verification

`gofmt`, `go vet ./...`, and `go test ./... -count=5 -race` all clean.

## Notes for review

- Two decisions here were judgment calls confirmed before implementing: dropping `RootRemover` rather than keeping it alongside the new contract, and extending best-effort to every name rather than just `"."`. Both narrow the API and change s3's subtree error behavior, so they are worth a look.
- This supersedes the first commit on the branch, which added `RootRemover` and the best-effort loop in the helper. The second commit removes both in favor of the interface contract. Worth reading the two commits in order, or just the squashed diff.