### PR TITLE
fs/internal/imptest: drop the stale skip note on ErrWalk

### DIFF
--- a/fs/internal/imptest/filewalker.go
+++ b/fs/internal/imptest/filewalker.go
@@ -32,10 +32,6 @@ type WalkFiles struct {
 	// is a BucketFS over an API that errors when asked to list the
 	// "blocked/" prefix; for local it is an FS where "blocked" is a regular
 	// file where the walk expects a directory, so the directory read fails.
-	//
-	// The subtest that uses it is skipped pending #165, so the fixture is
-	// built and not run; it stays wired up so closing that issue is a
-	// one-line change.
 	ErrWalk func(t *testing.T) ocflfs.WriteFS
 }
 


### PR DESCRIPTION
The ErrWalk doc says the subtest using the fixture is "skipped pending
#165", so the fixture is built and not run. Neither half is true: #165 is
closed, and "walk errors are delivered and terminate iteration" has no
skip -- it runs the fixture on both backends. Only the sentence describing
what the fixture is stays.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BqVx31tJdcFRWtVewGc2ez