### PR TITLE
fs/s3/internal/mock: give delete and not-found their real shapes

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -70,6 +70,15 @@ type WriteFS interface {
 	// errors.Is(err, fs.ErrNotExist). Name "." is never removable -- it
 	// names the storage root, not a file -- and returns an error satisfying
 	// errors.Is(err, fs.ErrInvalid) without affecting the root's contents.
+	//
+	// The missing-file case is a guarantee rather than a best effort, and
+	// holds on a backend whose own delete cannot supply it: S3's
+	// DeleteObject is idempotent, answering the same way whether or not the
+	// key was there, so the s3 implementation establishes existence itself
+	// before deleting and pays a round trip for it. A caller can therefore
+	// read fs.ErrNotExist as "there was nothing to remove" without knowing
+	// which storage it is talking to -- which is what lets undoing a
+	// partial write mean the same thing on every backend.
 	Remove(ctx context.Context, name string) error
 	// Remove the directory with path name and all its contents. If the path
 	// does not exist, return nil.

--- a/fs/internal/imptest/imptest.go
+++ b/fs/internal/imptest/imptest.go
@@ -44,23 +44,6 @@
 // backends agreed. If both callers would pass the same value, the knob should
 // not exist; assert the behavior directly instead.
 //
-// # Behavior no backend satisfies yet
-//
-// The suite landed before the fixes it exists to guard, so some of what it
-// asserts is not true on main yet. Those subtests are written out in full and
-// skipped where they stand, under a TODO naming the issue that closes the
-// gap:
-//
-//	// TODO(#166): s3's remove() calls the idempotent DeleteObject with no
-//	// existence check ... drop the skip when #166 adds the HEAD probe.
-//	t.Skip("Remove of a missing key returns nil on the s3 backend; see #166")
-//
-// The skip is unconditional rather than per-backend, so a subtest one backend
-// already satisfies is skipped for both — the TODO says which, so the fixing
-// PR knows what it is turning on. Writing the test now and skipping it is the
-// point: the PR that fixes the defect deletes one line, and its diff shows
-// exactly which behavior it makes good on.
-//
 // # Import direction
 //
 // Every caller lives in an external test package (package local_test, package

--- a/fs/internal/imptest/writefs.go
+++ b/fs/internal/imptest/writefs.go
@@ -161,11 +161,6 @@ func TestWriteFSRemove(t *testing.T, fsys ocflfs.WriteFS) {
 	ctx := context.Background()
 
 	t.Run("remove missing file returns ErrNotExist", func(t *testing.T) {
-		// TODO(#166): s3's remove() calls the idempotent DeleteObject with no
-		// existence check, so a key that was never there deletes
-		// successfully and Remove reports nil. The local backend already
-		// satisfies this; drop the skip when #166 adds the HEAD probe.
-		t.Skip("Remove of a missing key returns nil on the s3 backend; see #166")
 		const missing = "no-such-file.txt"
 		err := fsys.Remove(ctx, missing)
 		be.True(t, err != nil)

--- a/fs/s3/doc.go
+++ b/fs/s3/doc.go
@@ -1,0 +1,53 @@
+// Package s3 implements the [ocflfs] storage interfaces over an S3 bucket, so
+// an OCFL storage root can live in a bucket instead of a directory.
+//
+// [BucketFS] is the implementation. It is constructed over an [S3API] -- the
+// full set of SDK methods the package uses -- which the AWS SDK's *s3.Client
+// satisfies:
+//
+//	fsys := s3.NewBucketFS(s3.NewFromConfig(cfg), "my-bucket")
+//
+// S3API is composed of one narrower interface per operation (OpenFileAPI,
+// RemoveAPI, RemoveAllAPI, ...). Those exist so a caller can hand a
+// purpose-built client to the package-level helpers, and so this
+// documentation can say which SDK calls each operation makes.
+//
+// # Where S3 differs from a filesystem
+//
+// The point of [ocflfs] is that a caller can swap backends, so where S3's
+// semantics differ from a directory's, this package pays to hide the
+// difference rather than passing it on:
+//
+//   - [BucketFS.Remove] issues a HeadObject before its DeleteObject. Deleting
+//     an object is idempotent -- the endpoint answers the same way whether or
+//     not the key was there -- and the WriteFS contract requires
+//     fs.ErrNotExist for a name that is not there. So Remove costs two round
+//     trips, and the pair is not atomic: a key another writer removes in
+//     between reads as removed rather than missing.
+//
+//   - [BucketFS.RemoveAll] lists keys under a prefix and deletes each page
+//     with a single DeleteObjects request, so it costs a request per thousand
+//     files rather than one per file. Deletion is best-effort across the
+//     whole listing, and the per-key failures a DeleteObjects response
+//     reports are joined into the returned error rather than being lost
+//     behind a successful HTTP status.
+//
+//   - A missing key is reported as an error satisfying errors.Is(err,
+//     fs.ErrNotExist) whatever shape the store's error arrived in -- a typed
+//     SDK error, an API error code, or a bare 404 -- with the original error
+//     still reachable through errors.As. A missing bucket is deliberately not
+//     reported that way: it is a configuration error, not a missing file.
+//
+// # Compatibility
+//
+// The interfaces above are part of the API, so changing them breaks any
+// implementer that does not embed *s3.Client. Recent changes:
+//
+//   - RemoveAPI gained HeadObject, for the existence probe described above.
+//     S3API already required it through OpenFileAPI, so only a standalone
+//     RemoveAPI implementer is affected.
+//
+//   - RemoveAllAPI now requires DeleteObjects in place of DeleteObject, for
+//     the batching described above. An implementer of the whole S3API must
+//     add the method; DeleteObject is still required, by RemoveAPI.
+package s3

--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -112,6 +112,19 @@ func (f *BucketFS) Remove(ctx context.Context, name string) error {
 	return remove(ctx, f.client, f.bucket, name)
 }
 
+// RemoveAll deletes every object under name, per [ocflfs.WriteFS]. Name "."
+// empties the bucket. A name that matches nothing is not an error.
+//
+// Keys are listed a page at a time and each page is deleted in as few
+// DeleteObjects requests as the API allows, so removing an OCFL object costs
+// a request per thousand files rather than one per file.
+//
+// Deletion is best-effort: a key that will not delete does not abandon the
+// keys after it, on that page or on any later one. Only a failed listing
+// stops the walk, since without one there is nothing left to attempt. The
+// returned error joins every failure, naming the key each one is about --
+// including the per-key failures DeleteObjects reports in an otherwise
+// successful response.
 func (f *BucketFS) RemoveAll(ctx context.Context, name string) error {
 	f.debugLog(ctx, "s3:remove_all", "bucket", f.bucket, "name", name)
 	return removeAll(ctx, f.client, f.bucket, name)
@@ -218,10 +231,14 @@ type RemoveAPI interface {
 	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 }
 
-// RemoveAllAPI includes S3 methods needed for RemoveAll()
+// RemoveAllAPI includes S3 methods needed for RemoveAll().
+//
+// The delete is DeleteObjects, not DeleteObject: RemoveAll deletes a whole
+// listing page per request rather than one key per request. See
+// [BucketFS.RemoveAll].
 type RemoveAllAPI interface {
 	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
-	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	DeleteObjects(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
 }
 
 // ObjectRootsAPI includes S3 methods needed for ObjectRoots()

--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -96,6 +96,17 @@ func (f *BucketFS) Copy(ctx context.Context, dst, src string) (int64, error) {
 	return copy(ctx, f.client, f.bucket, dst, src, f.multiPartCopyOptions...)
 }
 
+// Remove deletes the object at name, per [ocflfs.WriteFS].
+//
+// Removing a key that is not in the bucket returns an error satisfying
+// errors.Is(err, fs.ErrNotExist), which S3 does not give for free: DeleteObject
+// answers 204 whether or not the key was there. Remove therefore issues a
+// HeadObject first, so it costs two round trips rather than one, and the pair
+// is not atomic -- a key deleted by another writer between the HEAD and the
+// DELETE is reported as removed rather than missing.
+//
+// Name "." is rejected with fs.ErrInvalid without issuing any request: it
+// names the bucket, not an object.
 func (f *BucketFS) Remove(ctx context.Context, name string) error {
 	f.debugLog(ctx, "s3:remove", "bucket", f.bucket, "name", name)
 	return remove(ctx, f.client, f.bucket, name)
@@ -197,8 +208,13 @@ type MultiCopyAPI interface {
 	AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput, ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error)
 }
 
-// RemoveAPI includes S3 methods needed for Remove()
+// RemoveAPI includes S3 methods needed for Remove().
+//
+// HeadObject is here because DeleteObject is idempotent and cannot report a
+// key that was never there, which the WriteFS.Remove contract requires. See
+// [BucketFS.Remove].
 type RemoveAPI interface {
+	HeadObject(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 }
 

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"iter"
@@ -17,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -809,6 +811,10 @@ func (stubClient) CopyObject(context.Context, *s3v2.CopyObjectInput, ...func(*s3
 	return nil, nil
 }
 
+func (stubClient) DeleteObjects(context.Context, *s3v2.DeleteObjectsInput, ...func(*s3v2.Options)) (*s3v2.DeleteObjectsOutput, error) {
+	return nil, nil
+}
+
 func (stubClient) DeleteObject(context.Context, *s3v2.DeleteObjectInput, ...func(*s3v2.Options)) (*s3v2.DeleteObjectOutput, error) {
 	return nil, nil
 }
@@ -1162,38 +1168,244 @@ func (s *seekerReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 	return s.rs.Read(p)
 }
 
-// failDeleteAPI is the mock with DeleteObject made to fail for one chosen key.
+// failDeleteAPI is the mock with DeleteObjects made to report a failure for
+// one chosen key. The failure is not a transport error: DeleteObjects answers
+// 200 and names the key in the response's Errors list, which is how a real
+// endpoint reports a key that would not delete. Every other key in the batch
+// deletes as usual.
+//
 // The mock records calls but injects no errors, and does not need to: the
 // method set it satisfies is an interface, so shadowing one method on an
 // embedding type is enough to stand in for the whole thing.
 type failDeleteAPI struct {
 	*mock.S3API
 	failKey string
-	err     error
-	// attempted records every key DeleteObject was called with. The mock's
-	// own call log cannot serve here: the failing key never reaches it.
+	code    string
+	message string
+	// pageSize, when > 0, clamps the listing page size so the keys span
+	// several pages -- enough to show that a page whose delete reported a
+	// failure is still followed by the next one.
+	pageSize int32
+	// attempted records every key a delete request carried. The mock's own
+	// call log cannot serve here: the failing key is filtered out before
+	// the request reaches it.
 	attempted []string
 }
 
-func (a *failDeleteAPI) DeleteObject(ctx context.Context, in *s3v2.DeleteObjectInput,
-	opts ...func(*s3v2.Options)) (*s3v2.DeleteObjectOutput, error) {
-	if in.Key != nil {
-		a.attempted = append(a.attempted, *in.Key)
+func (a *failDeleteAPI) ListObjectsV2(ctx context.Context, in *s3v2.ListObjectsV2Input,
+	opts ...func(*s3v2.Options)) (*s3v2.ListObjectsV2Output, error) {
+	if a.pageSize <= 0 {
+		return a.S3API.ListObjectsV2(ctx, in, opts...)
 	}
-	if in.Key != nil && *in.Key == a.failKey {
-		return nil, a.err
+	req := *in
+	req.MaxKeys = aws.Int32(a.pageSize)
+	return a.S3API.ListObjectsV2(ctx, &req, opts...)
+}
+
+func (a *failDeleteAPI) DeleteObjects(ctx context.Context, in *s3v2.DeleteObjectsInput,
+	opts ...func(*s3v2.Options)) (*s3v2.DeleteObjectsOutput, error) {
+	kept := make([]types.ObjectIdentifier, 0, len(in.Delete.Objects))
+	var failed *types.Error
+	for _, obj := range in.Delete.Objects {
+		key := aws.ToString(obj.Key)
+		a.attempted = append(a.attempted, key)
+		if key == a.failKey {
+			failed = &types.Error{
+				Key:     obj.Key,
+				Code:    aws.String(a.code),
+				Message: aws.String(a.message),
+			}
+			continue
+		}
+		kept = append(kept, obj)
 	}
-	return a.S3API.DeleteObject(ctx, in, opts...)
+	if failed == nil {
+		return a.S3API.DeleteObjects(ctx, in, opts...)
+	}
+	if len(kept) == 0 {
+		// Nothing left to send: a real endpoint would still answer 200 with
+		// the one failure, and the mock rejects an empty request.
+		return &s3v2.DeleteObjectsOutput{Errors: []types.Error{*failed}}, nil
+	}
+	req := *in
+	del := *in.Delete
+	del.Objects = kept
+	req.Delete = &del
+	out, err := a.S3API.DeleteObjects(ctx, &req, opts...)
+	if err != nil {
+		return out, err
+	}
+	out.Errors = append(out.Errors, *failed)
+	return out, nil
+}
+
+// pageAPI is the mock with a chosen listing page size, so a test can exercise
+// the paging and batching paths without seeding thousands of objects: the
+// mock already honors MaxKeys and continuation tokens, so clamping the page
+// size drives the same loop a full bucket would.
+//
+// It also records every DeleteObjects request it served, which is how a test
+// sees the request shape -- the batch each one carried, and whether it asked
+// for quiet mode -- and can fail a chosen one at the transport level.
+type pageAPI struct {
+	*mock.S3API
+	pageSize int32
+	// failCall, when > 0, makes the DeleteObjects call with that 1-based
+	// number fail outright, the way a dropped connection would.
+	failCall int
+	failErr  error
+
+	deletes []*s3v2.DeleteObjectsInput
+}
+
+var _ s3.S3API = (*pageAPI)(nil)
+
+func (a *pageAPI) ListObjectsV2(ctx context.Context, in *s3v2.ListObjectsV2Input,
+	opts ...func(*s3v2.Options)) (*s3v2.ListObjectsV2Output, error) {
+	req := *in
+	req.MaxKeys = aws.Int32(a.pageSize)
+	return a.S3API.ListObjectsV2(ctx, &req, opts...)
+}
+
+func (a *pageAPI) DeleteObjects(ctx context.Context, in *s3v2.DeleteObjectsInput,
+	opts ...func(*s3v2.Options)) (*s3v2.DeleteObjectsOutput, error) {
+	a.deletes = append(a.deletes, in)
+	if a.failCall > 0 && len(a.deletes) == a.failCall {
+		return nil, a.failErr
+	}
+	return a.S3API.DeleteObjects(ctx, in, opts...)
+}
+
+// TestRemoveAllBatches_Mock covers how removeAll issues its deletes. Listing a
+// page and then deleting one key per request cost a round trip per file: an
+// OCFL object of 10,000 files took 10,000 sequential DeleteObject calls where
+// DeleteObjects takes a whole page at once.
+//
+// KeyBatchesFor is the assertion that catches a regression back to per-key
+// deletes. KeysFor cannot: 500 keys in one batch and 500 separate calls name
+// exactly the same keys.
+func TestRemoveAllBatches_Mock(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("one request per page, quietly", func(t *testing.T) {
+		keys := []string{"d/a", "d/b", "d/c", "d/d", "d/e"}
+		objects := make([]*mock.Object, len(keys))
+		for i, key := range keys {
+			objects[i] = &mock.Object{Key: key, Body: []byte(key)}
+		}
+		api := &pageAPI{S3API: mock.New(bucket, objects...), pageSize: 2}
+		fsys := s3.NewBucketFS(api, bucket)
+		be.NilErr(t, fsys.RemoveAll(ctx, "d"))
+
+		// Three pages of two, two, one -- one delete request each, carrying
+		// that page's keys and nothing else.
+		be.DeepEqual(t, [][]string{{"d/a", "d/b"}, {"d/c", "d/d"}, {"d/e"}},
+			api.KeyBatchesFor("DeleteObjects"))
+		// And not one per-key delete anywhere.
+		be.Equal(t, 0, api.CallCount("DeleteObject"))
+
+		// Quiet mode: the response then carries only the failures, which is
+		// all removeAll reads.
+		for _, in := range api.deletes {
+			be.True(t, aws.ToBool(in.Delete.Quiet))
+		}
+
+		// The keys are actually gone, not merely named in a request.
+		for _, key := range keys {
+			be.True(t, api.WasDeleted(key))
+		}
+	})
+
+	// The page size and the batch limit are separate numbers that happen to
+	// be equal today. A page larger than a batch must still be split, so a
+	// future page-size bump cannot silently send a request S3 rejects
+	// outright -- the mock enforces the limit the way a real endpoint does.
+	t.Run("a page larger than the batch limit is split", func(t *testing.T) {
+		const numKeys = mock.MaxDeleteBatch + 200
+		objects := make([]*mock.Object, numKeys)
+		for i := range objects {
+			objects[i] = &mock.Object{Key: fmt.Sprintf("d/%05d", i)}
+		}
+		api := &pageAPI{S3API: mock.New(bucket, objects...), pageSize: numKeys}
+		fsys := s3.NewBucketFS(api, bucket)
+		be.NilErr(t, fsys.RemoveAll(ctx, "d"))
+
+		batches := api.KeyBatchesFor("DeleteObjects")
+		be.Equal(t, 2, len(batches))
+		be.Equal(t, mock.MaxDeleteBatch, len(batches[0]))
+		be.Equal(t, 200, len(batches[1]))
+		be.Equal(t, numKeys, len(api.KeysFor("DeleteObjects")))
+	})
+
+	// DeleteObjects answers 200 even when individual keys fail, reporting
+	// them in the response body. Reading only the transport error would call
+	// a RemoveAll successful while the prefix is still partly populated.
+	t.Run("per-key failures are reported", func(t *testing.T) {
+		api := &failDeleteAPI{
+			S3API:   mock.New(bucket, &mock.Object{Key: "d/a"}, &mock.Object{Key: "d/b"}),
+			failKey: "d/b",
+			code:    "AccessDenied",
+			message: "Access Denied",
+		}
+		fsys := s3.NewBucketFS(api, bucket)
+
+		err := fsys.RemoveAll(ctx, "d")
+		be.True(t, err != nil)
+		// The error names the key that failed, not the name RemoveAll was
+		// called with, and carries the reason the response gave.
+		be.True(t, strings.Contains(err.Error(), "d/b"))
+		be.True(t, strings.Contains(err.Error(), "AccessDenied"))
+		be.False(t, strings.Contains(err.Error(), "d/a"))
+		var pathErr *fs.PathError
+		be.True(t, errors.As(err, &pathErr))
+		be.Equal(t, "removeall", pathErr.Op)
+		be.Equal(t, "d/b", pathErr.Path)
+
+		// The rest of the batch still deleted.
+		be.True(t, api.WasDeleted("d/a"))
+		be.False(t, api.WasDeleted("d/b"))
+	})
+
+	// A DeleteObjects that fails at the transport level says nothing about
+	// individual keys, so it is reported once against the name the caller
+	// passed -- and, being best-effort, does not stop the next page.
+	t.Run("a failed request does not stop the walk", func(t *testing.T) {
+		boom := errors.New("boom")
+		keys := []string{"d/a", "d/b", "d/c", "d/d"}
+		objects := make([]*mock.Object, len(keys))
+		for i, key := range keys {
+			objects[i] = &mock.Object{Key: key}
+		}
+		api := &pageAPI{
+			S3API:    mock.New(bucket, objects...),
+			pageSize: 2,
+			failCall: 1,
+			failErr:  boom,
+		}
+		fsys := s3.NewBucketFS(api, bucket)
+
+		err := fsys.RemoveAll(ctx, "d")
+		be.True(t, errors.Is(err, boom))
+
+		// Page 2 was listed and deleted anyway. The count comes from the
+		// wrapper's own record: the failing request never reaches the mock,
+		// so the mock's call log cannot see it.
+		be.Equal(t, 2, len(api.deletes))
+		be.False(t, api.WasDeleted("d/a"))
+		be.False(t, api.WasDeleted("d/b"))
+		be.True(t, api.WasDeleted("d/c"))
+		be.True(t, api.WasDeleted("d/d"))
+	})
 }
 
 // TestRemoveAllBestEffort pins the WriteFS.RemoveAll contract that one key
 // which will not delete must not abandon the keys after it. The subtree case
 // is the one this changed: removeAll used to return on the first failing
-// DeleteObject, leaving every later key in place and reporting only that one
-// failure.
+// delete, leaving every later key in place and reporting only that one
+// failure. Batching does not weaken it -- a page whose response reports a
+// failure must still be followed by the next page.
 func TestRemoveAllBestEffort(t *testing.T) {
 	ctx := context.Background()
-	boom := errors.New("boom")
 
 	// Keys are chosen so the failing one sorts in the middle: a listing is
 	// returned in key order, so a survivor after it is what proves the loop
@@ -1203,6 +1415,9 @@ func TestRemoveAllBestEffort(t *testing.T) {
 		remove  string
 		keys    []string
 		failKey string
+		// pageSize, when set, splits the keys across several listing pages
+		// so the failure lands on a page with pages after it.
+		pageSize int32
 	}{
 		{
 			name:    "dot",
@@ -1216,6 +1431,13 @@ func TestRemoveAllBestEffort(t *testing.T) {
 			keys:    []string{"dir/a.txt", "dir/b.txt", "dir/c.txt"},
 			failKey: "dir/b.txt",
 		},
+		{
+			name:     "across pages",
+			remove:   "dir",
+			keys:     []string{"dir/a.txt", "dir/b.txt", "dir/c.txt", "dir/d.txt"},
+			failKey:  "dir/a.txt",
+			pageSize: 2,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			objects := make([]*mock.Object, 0, len(tc.keys))
@@ -1223,15 +1445,18 @@ func TestRemoveAllBestEffort(t *testing.T) {
 				objects = append(objects, &mock.Object{Key: key, Body: []byte(key)})
 			}
 			api := &failDeleteAPI{
-				S3API:   mock.New(bucket, objects...),
-				failKey: tc.failKey,
-				err:     boom,
+				S3API:    mock.New(bucket, objects...),
+				failKey:  tc.failKey,
+				code:     "InternalError",
+				message:  "boom",
+				pageSize: tc.pageSize,
 			}
 			fsys := s3.NewBucketFS(api, bucket)
 
 			err := fsys.RemoveAll(ctx, tc.remove)
 			be.True(t, err != nil)
-			be.True(t, errors.Is(err, boom))
+			be.True(t, strings.Contains(err.Error(), "boom"))
+			be.True(t, strings.Contains(err.Error(), tc.failKey))
 
 			// Every key was attempted, the failing one included.
 			attempted := slices.Clone(api.attempted)

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -476,6 +476,9 @@ func TestRemove_Mock(t *testing.T) {
 		bucket string
 		key    string
 		mock   func(*testing.T) *mock.S3API
+		// api optionally wraps the mock, for a case that needs a failure
+		// the mock does not itself produce.
+		api    func(*testing.T, *mock.S3API) s3.S3API
 		expect func(*testing.T, *mock.S3API, error)
 	}
 	cases := []testCase{
@@ -496,6 +499,65 @@ func TestRemove_Mock(t *testing.T) {
 				be.NilErr(t, err)
 				be.True(t, state.WasDeleted("remove-me"))
 				be.False(t, state.WasDeleted("keep-me"))
+				// The probe precedes the delete and names the same key.
+				be.AllEqual(t, []string{"remove-me"}, state.KeysFor("HeadObject"))
+				be.AllEqual(t, []string{"remove-me"}, state.KeysFor("DeleteObject"))
+			},
+		}, {
+			// DeleteObject is idempotent, so without the HEAD probe this
+			// reports success for a key that was never in the bucket --
+			// silently changing what a revert means when storage moves
+			// from a directory to a bucket.
+			desc:   "remove missing key",
+			bucket: bucket,
+			key:    "never-existed",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket, &mock.Object{Key: "keep-me"})
+			},
+			expect: func(t *testing.T, state *mock.S3API, err error) {
+				be.True(t, errors.Is(err, fs.ErrNotExist))
+				var pathErr *fs.PathError
+				be.True(t, errors.As(err, &pathErr))
+				be.Equal(t, "remove", pathErr.Op)
+				be.Equal(t, "never-existed", pathErr.Path)
+				// The probe failed, so no delete was ever issued: a
+				// DeleteObject here would mean Remove had decided the key
+				// was there.
+				be.Equal(t, 0, state.CallCount("DeleteObject"))
+				// And the cause of the failed probe is still reachable.
+				var apiErr smithy.APIError
+				be.True(t, errors.As(err, &apiErr))
+				be.Equal(t, "NotFound", apiErr.ErrorCode())
+			},
+		}, {
+			// The same, against a store whose missing-key error the SDK
+			// cannot resolve to a typed error.
+			desc:   "remove missing key, generic not-found style",
+			bucket: bucket,
+			key:    "never-existed",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket).WithNotFoundStyle(mock.NotFoundStyleGeneric)
+			},
+			expect: func(t *testing.T, state *mock.S3API, err error) {
+				be.True(t, errors.Is(err, fs.ErrNotExist))
+				be.Equal(t, 0, state.CallCount("DeleteObject"))
+			},
+		}, {
+			// A probe that fails for any other reason is not a missing
+			// key, and must not be reported as one.
+			desc:   "probe fails for another reason",
+			bucket: bucket,
+			key:    "remove-me",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket, &mock.Object{Key: "remove-me"})
+			},
+			api: func(t *testing.T, m *mock.S3API) s3.S3API {
+				return &headErrAPI{S3API: m, err: respErr(403, &smithy.GenericAPIError{Code: "AccessDenied"})}
+			},
+			expect: func(t *testing.T, state *mock.S3API, err error) {
+				be.True(t, err != nil)
+				be.False(t, errors.Is(err, fs.ErrNotExist))
+				be.Equal(t, 0, state.CallCount("DeleteObject"))
 			},
 		},
 	}
@@ -505,7 +567,11 @@ func TestRemove_Mock(t *testing.T) {
 			if tcase.mock != nil {
 				api = tcase.mock(t)
 			}
-			fsys := s3.NewBucketFS(api, tcase.bucket)
+			var client s3.S3API = api
+			if tcase.api != nil {
+				client = tcase.api(t, api)
+			}
+			fsys := s3.NewBucketFS(client, tcase.bucket)
 			err := fsys.Remove(ctx, tcase.key)
 			tcase.expect(t, api, err)
 		})

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"iter"
+	"net/http"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -16,9 +17,12 @@ import (
 	"testing"
 	"time"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/carlmjohnson/be"
 	"github.com/srerickson/ocfl-go"
@@ -1180,4 +1184,165 @@ func TestRemoveAllBestEffort(t *testing.T) {
 			}
 		})
 	}
+}
+
+// headErrAPI is the mock with HeadObject made to fail with a chosen error, so
+// a test can present an error shape the mock does not itself produce.
+type headErrAPI struct {
+	*mock.S3API
+	err error
+}
+
+var _ s3.S3API = (*headErrAPI)(nil)
+
+func (a *headErrAPI) HeadObject(ctx context.Context, in *s3v2.HeadObjectInput,
+	opts ...func(*s3v2.Options)) (*s3v2.HeadObjectOutput, error) {
+	return nil, a.err
+}
+
+// respErr builds the error an endpoint's 404 arrives as: the API error the
+// SDK deserialized, inside the transport error carrying the response.
+func respErr(status int, inner error) error {
+	return &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{
+				Response: &http.Response{StatusCode: status, Header: http.Header{}},
+			},
+			Err: inner,
+		},
+		RequestID: "TESTREQUESTID",
+	}
+}
+
+// TestNotExistMapping_Mock covers which S3 API errors mean "not there" and
+// what the backend does with the ones that do.
+//
+// The shapes matter because they are not interchangeable: HeadObject has no
+// response body, so a real endpoint's 404 deserializes to *types.NotFound
+// rather than the *types.NoSuchKey a GetObject body carries, and an
+// S3-compatible store the SDK cannot type at all yields a
+// *smithy.GenericAPIError holding the code as a string. A check written
+// against one shape passes CI against a mock that speaks it and fails against
+// a store that does not.
+func TestNotExistMapping_Mock(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("recognized shapes", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			err  error
+		}{
+			{"typed NotFound", respErr(404, &types.NotFound{})},
+			{"typed NoSuchKey", respErr(404, &types.NoSuchKey{})},
+			{"generic code NotFound", respErr(404, &smithy.GenericAPIError{Code: "NotFound"})},
+			{"generic code NoSuchKey", respErr(404, &smithy.GenericAPIError{Code: "NoSuchKey"})},
+			// A store whose code neither the SDK nor this package knows:
+			// the 404 is the only thing left to go on, and it is enough.
+			{"unrecognized code with 404", respErr(404, &smithy.GenericAPIError{Code: "KeyNotPresent"})},
+			// Bare typed errors, with no transport error around them.
+			{"bare NotFound", &types.NotFound{}},
+			{"bare NoSuchKey", &types.NoSuchKey{}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				fsys := s3.NewBucketFS(&headErrAPI{S3API: mock.New(bucket), err: tc.err}, bucket)
+				_, err := fsys.OpenFile(ctx, "missing.txt")
+				be.True(t, errors.Is(err, fs.ErrNotExist))
+			})
+		}
+	})
+
+	t.Run("not-exist shapes it must not claim", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			err  error
+		}{
+			// A missing bucket is a 404 too, and is a configuration error
+			// rather than a missing file. Reporting fs.ErrNotExist would
+			// tell a caller the object was never written when in fact
+			// nothing can be read or written at all.
+			{"typed NoSuchBucket", respErr(404, &types.NoSuchBucket{})},
+			{"generic code NoSuchBucket", respErr(404, &smithy.GenericAPIError{Code: "NoSuchBucket"})},
+			{"access denied", respErr(403, &smithy.GenericAPIError{Code: "AccessDenied"})},
+			{"server error", respErr(500, &smithy.GenericAPIError{Code: "InternalError"})},
+			{"transport failure", errors.New("dial tcp: connection refused")},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				fsys := s3.NewBucketFS(&headErrAPI{S3API: mock.New(bucket), err: tc.err}, bucket)
+				_, err := fsys.OpenFile(ctx, "missing.txt")
+				be.True(t, err != nil)
+				be.False(t, errors.Is(err, fs.ErrNotExist))
+			})
+		}
+	})
+
+	// The mapping wraps fs.ErrNotExist around the cause instead of replacing
+	// it. Replacing threw away the status code, the request ID and the API
+	// error code -- most of what makes a failure against a real endpoint
+	// diagnosable -- and left a caller with an error it could match but not
+	// read.
+	t.Run("the cause survives the wrap", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			open func() error
+		}{
+			{
+				name: "OpenFile",
+				open: func() error {
+					fsys := s3.NewBucketFS(mock.New(bucket), bucket)
+					_, err := fsys.OpenFile(ctx, "missing.txt")
+					return err
+				},
+			},
+			{
+				name: "Copy",
+				open: func() error {
+					fsys := s3.NewBucketFS(mock.New(bucket), bucket)
+					_, err := fsys.Copy(ctx, "dst.txt", "missing.txt")
+					return err
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.open()
+				be.True(t, errors.Is(err, fs.ErrNotExist))
+
+				// Still a *fs.PathError naming the file, as before.
+				var pathErr *fs.PathError
+				be.True(t, errors.As(err, &pathErr))
+				be.Equal(t, "missing.txt", pathErr.Path)
+
+				// And the API error underneath is still reachable.
+				var apiErr smithy.APIError
+				be.True(t, errors.As(err, &apiErr))
+				be.Equal(t, "NotFound", apiErr.ErrorCode())
+				var respErr *smithyhttp.ResponseError
+				be.True(t, errors.As(err, &respErr))
+				be.Equal(t, 404, respErr.HTTPStatusCode())
+				var reqIDErr interface{ ServiceRequestID() string }
+				be.True(t, errors.As(err, &reqIDErr))
+				be.Equal(t, mock.RequestID(), reqIDErr.ServiceRequestID())
+			})
+		}
+	})
+
+	// The generic style is the one the old typed-only check missed: a store
+	// whose error the SDK cannot resolve to *types.NotFound or
+	// *types.NoSuchKey still has to read as a missing file end to end.
+	t.Run("generic style backend", func(t *testing.T) {
+		api := mock.New(bucket, &mock.Object{Key: "present.txt", Body: []byte("x")}).
+			WithNotFoundStyle(mock.NotFoundStyleGeneric)
+		fsys := s3.NewBucketFS(api, bucket)
+
+		_, err := fsys.OpenFile(ctx, "missing.txt")
+		be.True(t, errors.Is(err, fs.ErrNotExist))
+
+		_, err = fsys.Copy(ctx, "dst.txt", "missing.txt")
+		be.True(t, errors.Is(err, fs.ErrNotExist))
+
+		// A key that is there still opens: the mapping did not turn every
+		// error into a missing file.
+		file, err := fsys.OpenFile(ctx, "present.txt")
+		be.NilErr(t, err)
+		be.NilErr(t, file.Close())
+	})
 }

--- a/fs/s3/internal/mock/errors.go
+++ b/fs/s3/internal/mock/errors.go
@@ -1,0 +1,95 @@
+package mock
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// errMissingKey is the mock's internal sentinel for "the bucket does not hold
+// this key". It never reaches a caller: each handler converts it into the
+// error shape the configured NotFoundStyle produces, because the shape a
+// request gets back depends on which operation asked (a HEAD has no body to
+// deserialize a typed error from; a GET does) and getObjectLocked does not
+// know which one that was.
+var errMissingKey = errors.New("mock: no such key")
+
+// NotFoundStyle selects the error shape the mock returns for a request naming
+// a key the bucket does not hold. Two families of store are worth pinning,
+// because the s3 backend's not-exist mapping has to recognize both.
+type NotFoundStyle int
+
+const (
+	// NotFoundStyleAWS is what the SDK hands back from a real S3 endpoint:
+	// the operation's own typed error (*types.NotFound for HeadObject,
+	// *types.NoSuchKey for GetObject and CopyObject), wrapped in the
+	// *smithyhttp.ResponseError that carries the 404 response, wrapped in
+	// turn by the AWS transport's ResponseError that carries the request
+	// ID. A caller sees all three: errors.As finds the typed error, and
+	// the status and request ID stay reachable on the way to it.
+	//
+	// This is the default: a mock that lies about the common case is worse
+	// than no mock.
+	NotFoundStyleAWS NotFoundStyle = iota
+
+	// NotFoundStyleGeneric is what an S3-compatible store produces when the
+	// SDK cannot resolve a typed error for the code it sent back: a
+	// *smithy.GenericAPIError carrying the code as a string, still inside
+	// the 404 ResponseError. Nothing about it is deserializable into
+	// *types.NotFound or *types.NoSuchKey, so a not-exist check written
+	// against the typed errors alone does not recognize it.
+	NotFoundStyleGeneric
+)
+
+// notFound returns the error a request for a missing key gets back, in the
+// shape m is configured for. typed is the SDK error type the operation
+// declares for a missing key -- it is what NotFoundStyleAWS wraps, and what
+// NotFoundStyleGeneric replaces with a code-carrying generic error.
+func (m *S3API) notFound(typed smithy.APIError) error {
+	var inner error = typed
+	if m.notFoundStyle == NotFoundStyleGeneric {
+		inner = &smithy.GenericAPIError{
+			Code:    typed.ErrorCode(),
+			Message: typed.ErrorMessage(),
+		}
+	}
+	return &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{
+				Response: &http.Response{
+					StatusCode: http.StatusNotFound,
+					Status:     "404 Not Found",
+					Header:     http.Header{},
+				},
+			},
+			Err: inner,
+		},
+		RequestID: mockRequestID,
+	}
+}
+
+// mockRequestID stands in for the request ID a real endpoint returns. Tests
+// assert on it to show that the s3 backend's not-exist mapping keeps the
+// cause reachable instead of replacing it.
+const mockRequestID = "MOCKREQUESTID0001"
+
+// RequestID returns the request ID the mock stamps on its error responses.
+func RequestID() string { return mockRequestID }
+
+// noSuchKeyErr converts getObject's missing-key sentinel into the shape an
+// operation with a response body returns -- GetObject, CopyObject and
+// UploadPartCopy all deserialize *types.NoSuchKey from one. Any other error
+// passes through untouched.
+func (m *S3API) noSuchKeyErr(err error) error {
+	if !errors.Is(err, errMissingKey) {
+		return err
+	}
+	return m.notFound(&types.NoSuchKey{
+		Message: aws.String("The specified key does not exist."),
+	})
+}

--- a/fs/s3/internal/mock/errors_test.go
+++ b/fs/s3/internal/mock/errors_test.go
@@ -1,0 +1,156 @@
+package mock_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/carlmjohnson/be"
+
+	"github.com/srerickson/ocfl-go/fs/s3/internal/mock"
+)
+
+const errBucket = "mock-errors-test"
+
+// TestDeleteObjectIsIdempotent pins the half of the DeleteObject contract that
+// the s3 backend's Remove has to work around: a real endpoint answers 204 for
+// a key that was never there and says nothing about which it was. The mock
+// used to return NoSuchKey instead, which made the backend's Remove look
+// strict under test while returning nil against a real bucket.
+func TestDeleteObjectIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	api := mock.New(errBucket, &mock.Object{Key: "present.txt"})
+
+	out, err := api.DeleteObject(ctx, &s3v2.DeleteObjectInput{
+		Bucket: aws.String(errBucket),
+		Key:    aws.String("never-existed.txt"),
+	})
+	be.NilErr(t, err)
+	be.True(t, out != nil)
+
+	// Deleting a key that is there behaves the same way, and the key stops
+	// answering HeadObject.
+	_, err = api.DeleteObject(ctx, &s3v2.DeleteObjectInput{
+		Bucket: aws.String(errBucket),
+		Key:    aws.String("present.txt"),
+	})
+	be.NilErr(t, err)
+	_, err = api.HeadObject(ctx, &s3v2.HeadObjectInput{
+		Bucket: aws.String(errBucket),
+		Key:    aws.String("present.txt"),
+	})
+	be.True(t, err != nil)
+
+	// Both requests are in the call log, so a test can still tell which
+	// keys a delete named even though neither failed.
+	be.AllEqual(t, []string{"never-existed.txt", "present.txt"}, api.KeysFor("DeleteObject"))
+
+	// A request naming the wrong bucket still fails: idempotence is about
+	// the key, not about accepting anything.
+	_, err = api.DeleteObject(ctx, &s3v2.DeleteObjectInput{
+		Bucket: aws.String("some-other-bucket"),
+		Key:    aws.String("present.txt"),
+	})
+	be.True(t, err != nil)
+}
+
+// TestNotFoundShapes pins the error shapes a request for a missing key comes
+// back as. They are what the s3 backend's not-exist mapping is written
+// against, so a mock that invents its own shape hides whether that mapping
+// works against a real store.
+func TestNotFoundShapes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("aws style", func(t *testing.T) {
+		api := mock.New(errBucket)
+
+		// HeadObject: no response body, so a real endpoint's code is
+		// derived from the 404 status and deserializes to *types.NotFound.
+		_, err := api.HeadObject(ctx, &s3v2.HeadObjectInput{
+			Bucket: aws.String(errBucket),
+			Key:    aws.String("missing.txt"),
+		})
+		be.True(t, err != nil)
+		var notFound *types.NotFound
+		be.True(t, errors.As(err, &notFound))
+
+		// GetObject: the body carries NoSuchKey.
+		_, err = api.GetObject(ctx, &s3v2.GetObjectInput{
+			Bucket: aws.String(errBucket),
+			Key:    aws.String("missing.txt"),
+		})
+		be.True(t, err != nil)
+		var noSuchKey *types.NoSuchKey
+		be.True(t, errors.As(err, &noSuchKey))
+
+		// Either way the transport error is reachable, carrying the status
+		// and request ID a caller needs to make sense of a failure.
+		var respErr *smithyhttp.ResponseError
+		be.True(t, errors.As(err, &respErr))
+		be.Equal(t, 404, respErr.HTTPStatusCode())
+		var reqIDErr interface{ ServiceRequestID() string }
+		be.True(t, errors.As(err, &reqIDErr))
+		be.Equal(t, mock.RequestID(), reqIDErr.ServiceRequestID())
+	})
+
+	t.Run("generic style", func(t *testing.T) {
+		api := mock.New(errBucket).WithNotFoundStyle(mock.NotFoundStyleGeneric)
+
+		for _, tc := range []struct {
+			op   string
+			call func() error
+			code string
+		}{
+			{
+				op:   "HeadObject",
+				code: "NotFound",
+				call: func() error {
+					_, err := api.HeadObject(ctx, &s3v2.HeadObjectInput{
+						Bucket: aws.String(errBucket),
+						Key:    aws.String("missing.txt"),
+					})
+					return err
+				},
+			},
+			{
+				op:   "GetObject",
+				code: "NoSuchKey",
+				call: func() error {
+					_, err := api.GetObject(ctx, &s3v2.GetObjectInput{
+						Bucket: aws.String(errBucket),
+						Key:    aws.String("missing.txt"),
+					})
+					return err
+				},
+			},
+		} {
+			t.Run(tc.op, func(t *testing.T) {
+				err := tc.call()
+				be.True(t, err != nil)
+
+				// The code survives as a string on a generic error...
+				var apiErr *smithy.GenericAPIError
+				be.True(t, errors.As(err, &apiErr))
+				be.Equal(t, tc.code, apiErr.ErrorCode())
+
+				// ...and there is nothing typed to find, which is the whole
+				// point of pinning this style: a not-exist check written
+				// against the typed errors alone does not recognize it.
+				var notFound *types.NotFound
+				be.False(t, errors.As(err, &notFound))
+				var noSuchKey *types.NoSuchKey
+				be.False(t, errors.As(err, &noSuchKey))
+
+				// The 404 is still there to be read.
+				var respErr *smithyhttp.ResponseError
+				be.True(t, errors.As(err, &respErr))
+				be.Equal(t, 404, respErr.HTTPStatusCode())
+			})
+		}
+	})
+}

--- a/fs/s3/internal/mock/mock.go
+++ b/fs/s3/internal/mock/mock.go
@@ -40,6 +40,18 @@ func New(bucket string, objects ...*Object) *S3API {
 	return api
 }
 
+// WithNotFoundStyle sets the error shape m returns for a request naming a key
+// the bucket does not hold, and returns m so it can be chained onto New:
+//
+//	mock.New(bucket, objs...).WithNotFoundStyle(mock.NotFoundStyleGeneric)
+//
+// The default is [NotFoundStyleAWS]. Set it before serving any request: the
+// field is read without the state lock.
+func (m *S3API) WithNotFoundStyle(style NotFoundStyle) *S3API {
+	m.notFoundStyle = style
+	return m
+}
+
 type S3API struct {
 	// UpdatedETags, Deleted and the MPU flags are written by the mock's
 	// handlers and read by tests. Handlers may run on the uploader's
@@ -66,6 +78,11 @@ type S3API struct {
 	bucket  string
 	objects map[string]*Object
 
+	// notFoundStyle selects the error shape returned for a missing key.
+	// It is set at construction and never written afterwards, so it needs
+	// no lock. See errors.go.
+	notFoundStyle NotFoundStyle
+
 	// mu guards objects, UpdatedETags, Deleted and the MPU flags. parts
 	// keeps its own sync.Map and log its own mutex, so a handler never
 	// holds mu while touching either — no lock ordering to reason about.
@@ -82,6 +99,12 @@ func (m *S3API) HeadObject(ctx context.Context, in *s3v2.HeadObjectInput, opts .
 		return nil, err
 	}
 	obj, err := m.getObject(in.Key)
+	if errors.Is(err, errMissingKey) {
+		// A HEAD response has no body, so a real endpoint has nothing to
+		// deserialize a code from and the SDK derives one from the 404
+		// status: NotFound, not NoSuchKey.
+		err = m.notFound(&types.NotFound{Message: aws.String("Not Found")})
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +128,7 @@ func (m *S3API) GetObject(ctx context.Context, in *s3v2.GetObjectInput, opts ...
 	obj, err := m.getObjectLocked(in.Key)
 	if err != nil {
 		m.mu.Unlock()
-		return nil, err
+		return nil, m.noSuchKeyErr(err)
 	}
 	body := obj.Body
 	lastMod := obj.LastModified
@@ -317,7 +340,7 @@ func (m *S3API) UploadPartCopy(ctx context.Context, in *s3v2.UploadPartCopyInput
 	}
 	srcObj, err := m.getObject(&srcKey)
 	if err != nil {
-		return nil, err
+		return nil, m.noSuchKeyErr(err)
 	}
 	if in.CopySourceRange == nil {
 		return nil, errors.New("CopySourceRange is required")
@@ -432,7 +455,7 @@ func (m *S3API) CopyObject(ctx context.Context, in *s3v2.CopyObjectInput, opts .
 	}
 	srcObj, err := m.getObject(&srcKey)
 	if err != nil {
-		return nil, err
+		return nil, m.noSuchKeyErr(err)
 	}
 	// Copy the body under the state lock: a concurrent PutObject to the
 	// source key would otherwise race the read in md5hex.
@@ -454,14 +477,20 @@ func (m *S3API) CopyObject(ctx context.Context, in *s3v2.CopyObjectInput, opts .
 
 func (m *S3API) DeleteObject(ctx context.Context, in *s3v2.DeleteObjectInput, opts ...func(*s3v2.Options)) (*s3v2.DeleteObjectOutput, error) {
 	m.log.recordKey("DeleteObject", in.Key)
+	if err := m.bucketOK(in.Bucket); err != nil {
+		return nil, err
+	}
+	if in.Key == nil {
+		return nil, errors.New("key is required")
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, err := m.getObjectLocked(in.Key); err != nil {
-		return nil, &types.NoSuchKey{}
-	}
-	out := &s3v2.DeleteObjectOutput{}
+	// DeleteObject is idempotent: a real endpoint answers 204 whether or
+	// not the key was there, and reports nothing about which it was. A
+	// mock that errored on a missing key would let the s3 backend's Remove
+	// look strict under test while returning nil in production.
 	m.deleteKeyLocked(*in.Key)
-	return out, nil
+	return &s3v2.DeleteObjectOutput{}, nil
 }
 
 // deleteKeyLocked removes the object from the bucket and records the
@@ -566,7 +595,7 @@ func (m *S3API) getObjectLocked(k *string) (*Object, error) {
 	}
 	obj, ok := m.objects[*k]
 	if !ok {
-		return nil, &types.NoSuchKey{}
+		return nil, errMissingKey
 	}
 	return obj, nil
 }

--- a/fs/s3/internal/mock/mock.go
+++ b/fs/s3/internal/mock/mock.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/srerickson/ocfl-go/fs/s3"
 )
 
@@ -491,6 +492,53 @@ func (m *S3API) DeleteObject(ctx context.Context, in *s3v2.DeleteObjectInput, op
 	// look strict under test while returning nil in production.
 	m.deleteKeyLocked(*in.Key)
 	return &s3v2.DeleteObjectOutput{}, nil
+}
+
+// MaxDeleteBatch is the most keys DeleteObjects accepts in one request. It is
+// a fixed S3 API limit, not a tunable, and the mock enforces it: a caller that
+// batches a listing page must not be able to send an oversized request that
+// only a real endpoint rejects.
+const MaxDeleteBatch = 1000
+
+func (m *S3API) DeleteObjects(ctx context.Context, in *s3v2.DeleteObjectsInput, opts ...func(*s3v2.Options)) (*s3v2.DeleteObjectsOutput, error) {
+	// Record every key the request carried, so a test can tell one batch of
+	// n keys from n separate DeleteObject calls -- KeysFor is identical for
+	// the two, KeyBatchesFor is not.
+	var keys []string
+	if in.Delete != nil {
+		for _, obj := range in.Delete.Objects {
+			keys = append(keys, aws.ToString(obj.Key))
+		}
+	}
+	m.log.record("DeleteObjects", keys...)
+	if err := m.bucketOK(in.Bucket); err != nil {
+		return nil, err
+	}
+	if in.Delete == nil || len(in.Delete.Objects) == 0 {
+		return nil, errors.New("Delete with at least one object is required")
+	}
+	if len(in.Delete.Objects) > MaxDeleteBatch {
+		return nil, &smithy.GenericAPIError{
+			Code:    "MalformedXML",
+			Message: fmt.Sprintf("a delete request carries at most %d keys, got %d", MaxDeleteBatch, len(in.Delete.Objects)),
+		}
+	}
+	quiet := aws.ToBool(in.Delete.Quiet)
+	out := &s3v2.DeleteObjectsOutput{}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, obj := range in.Delete.Objects {
+		if obj.Key == nil {
+			return nil, errors.New("object key is required")
+		}
+		// Each key deletes the way DeleteObject does: idempotently, whether
+		// or not the bucket held it.
+		m.deleteKeyLocked(*obj.Key)
+		if !quiet {
+			out.Deleted = append(out.Deleted, types.DeletedObject{Key: obj.Key})
+		}
+	}
+	return out, nil
 }
 
 // deleteKeyLocked removes the object from the bucket and records the

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -38,10 +38,18 @@ const (
 	dirMode  = 0755 | fs.ModeDir
 )
 
+// maxDeleteBatch is the most keys DeleteObjects accepts in one request. It is
+// a fixed S3 API limit, not a tunable: a larger request is rejected outright.
+// removeAll splits each listing page into batches of this size, so the page
+// size below can change without silently sending an oversized delete.
+const maxDeleteBatch = 1000
+
 var (
 	// these are variable because we need pass them as pointers
-	delim         = "/"
-	maxKeys int32 = 1000
+	delim = "/"
+	// maxKeys is the page size for every listing in this package. It is the
+	// batch limit today, which makes a page exactly one delete request.
+	maxKeys int32 = maxDeleteBatch
 )
 
 // Compile-time check that s3File implements io.Seeker
@@ -263,7 +271,8 @@ func removeAll(ctx context.Context, api RemoveAllAPI, buck string, name string) 
 	// Deletion is best-effort, per the WriteFS.RemoveAll contract: one key
 	// that will not delete must not abandon the keys after it, which would
 	// leave a partial deletion and report only the first of possibly many
-	// failures.
+	// failures. That holds across pages too -- a page that reports failures
+	// must still be followed by the next one.
 	var errs error
 	for {
 		list, err := api.ListObjectsV2(ctx, params)
@@ -272,25 +281,77 @@ func removeAll(ctx context.Context, api RemoveAllAPI, buck string, name string) 
 			// this one does stop the loop.
 			return errors.Join(errs, pathErr("removeall", name, err))
 		}
-		for _, obj := range list.Contents {
-			_, err := api.DeleteObject(ctx, &s3.DeleteObjectInput{
-				Bucket: &buck,
-				Key:    obj.Key,
-			})
-			if err != nil {
-				key := name
-				if obj.Key != nil {
-					key = *obj.Key
-				}
-				errs = errors.Join(errs, pathErr("removeall", key, err))
-			}
-		}
+		errs = errors.Join(errs, deleteKeys(ctx, api, buck, name, list.Contents))
 		params.ContinuationToken = list.NextContinuationToken
 		if params.ContinuationToken == nil {
 			break
 		}
 	}
 	return errs
+}
+
+// deleteKeys deletes one listing page in as few requests as the API allows,
+// and returns every per-key failure it can see, joined.
+//
+// name is the name the caller passed RemoveAll; it is used only for a failure
+// that says nothing about individual keys.
+func deleteKeys(ctx context.Context, api RemoveAllAPI, buck, name string, contents []types.Object) error {
+	ids := make([]types.ObjectIdentifier, 0, len(contents))
+	for _, obj := range contents {
+		if obj.Key == nil {
+			continue
+		}
+		ids = append(ids, types.ObjectIdentifier{Key: obj.Key})
+	}
+	var errs error
+	for batch := range slices.Chunk(ids, maxDeleteBatch) {
+		out, err := api.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: &buck,
+			Delete: &types.Delete{
+				Objects: batch,
+				// In quiet mode the response carries only the keys that
+				// failed, which is all this code reads.
+				Quiet: aws.Bool(true),
+			},
+		})
+		if err != nil {
+			// A transport-level failure says nothing about individual keys:
+			// every key in the batch is simply unaccounted for. Report it
+			// once against the name the caller passed rather than repeating
+			// it for up to maxDeleteBatch keys, and keep going -- the next
+			// batch and the next page may well succeed.
+			errs = errors.Join(errs, pathErr("removeall", name, err))
+			continue
+		}
+		// DeleteObjects answers 200 even when individual keys fail, listing
+		// them in the response body. Checking only the transport error would
+		// report a successful RemoveAll for a prefix that is still partly
+		// populated -- worse than the per-key loop this replaced, which at
+		// least saw each failure.
+		if out == nil {
+			continue
+		}
+		for _, e := range out.Errors {
+			errs = errors.Join(errs, pathErr("removeall", aws.ToString(e.Key), deleteErr(e)))
+		}
+	}
+	return errs
+}
+
+// deleteErr turns one entry of a DeleteObjects response's Errors list into an
+// error. Neither field is guaranteed to be set, so the fallbacks matter: a
+// failure reported with no reason at all still has to read as a failure.
+func deleteErr(e types.Error) error {
+	code, msg := aws.ToString(e.Code), aws.ToString(e.Message)
+	switch {
+	case code != "" && msg != "":
+		return fmt.Errorf("%s: %s", code, msg)
+	case code != "":
+		return errors.New(code)
+	case msg != "":
+		return errors.New(msg)
+	}
+	return errors.New("delete failed, no reason reported")
 }
 
 // walkFiles returns an iterator that yields PathInfo for files in the dir

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -217,6 +217,28 @@ func remove(ctx context.Context, api RemoveAPI, b string, name string) error {
 	if name == "." {
 		return pathErr("remove", name, fs.ErrInvalid)
 	}
+	// DeleteObject is idempotent: it answers 204 whether or not the key was
+	// there, and says nothing about which it was. The WriteFS.Remove
+	// contract requires fs.ErrNotExist for a name that is not there, so the
+	// existence has to be established separately, with a HEAD.
+	//
+	// Two consequences, documented rather than engineered around. The probe
+	// is not atomic with the delete: a key another writer removes between
+	// the HEAD and the DELETE is reported as removed, since the DELETE
+	// succeeds either way. And Remove costs two round trips instead of one.
+	// The library calls Remove only to undo a failed update and to replace
+	// the storage root's layout file, so the extra HEAD lands off the happy
+	// path; a caller that removes keys in bulk should use RemoveAll, which
+	// still lists and deletes without probing.
+	if _, err := api.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: &b,
+		Key:    aws.String(name),
+	}); err != nil {
+		if errIsNotExist(err) {
+			err = notExistErr(err)
+		}
+		return pathErr("remove", name, err)
+	}
 	_, err := api.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &b,
 		Key:    aws.String(name),

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"iter"
+	"net/http"
 	"net/url"
 	"path"
 	"slices"
@@ -18,6 +19,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	ocflfs "github.com/srerickson/ocfl-go/fs"
 )
 
@@ -51,15 +54,10 @@ func openFile(ctx context.Context, api OpenFileAPI, buck string, name string) (f
 	headIn := &s3.HeadObjectInput{Bucket: &buck, Key: &name}
 	headOut, err := api.HeadObject(ctx, headIn)
 	if err != nil {
-		fsErr := &fs.PathError{
-			Op:   "open",
-			Path: name,
-			Err:  err,
-		}
 		if errIsNotExist(err) {
-			fsErr.Err = fs.ErrNotExist
+			err = notExistErr(err)
 		}
-		return nil, fsErr
+		return nil, pathErr("open", name, err)
 	}
 	f := &s3File{
 		ctx:    ctx,
@@ -185,15 +183,10 @@ func copy(ctx context.Context, api CopyAPI, buck string, dst, src string, opts .
 		Key:    &src,
 	})
 	if err != nil {
-		fsErr := &fs.PathError{
-			Op:   "copy",
-			Path: src,
-			Err:  err,
-		}
 		if errIsNotExist(err) {
-			fsErr.Err = fs.ErrNotExist
+			err = notExistErr(err)
 		}
-		return 0, fsErr
+		return 0, pathErr("copy", src, err)
 	}
 	escapedSrc := url.QueryEscape(buck + "/" + src)
 	params := &s3.CopyObjectInput{
@@ -483,11 +476,52 @@ func byteRange(partNum int32, partSize, totalSize int64) string {
 	return fmt.Sprintf("bytes=%d-%d", start, end)
 }
 
+// errIsNotExist reports whether err is an S3 API error meaning "that object
+// is not there". Four shapes reach here, because what comes back depends on
+// the operation and on the store:
+//
+//   - *types.NoSuchKey, deserialized from the response body of GetObject,
+//     CopyObject and UploadPartCopy;
+//   - *types.NotFound, which is what HeadObject produces: a HEAD response
+//     has no body to deserialize a code from, so the SDK derives one from
+//     the 404 status;
+//   - *smithy.GenericAPIError carrying the code as a string, from an
+//     S3-compatible store that sent a code the SDK could not resolve to one
+//     of the typed errors;
+//   - any error carrying a 404 response, for a store whose code neither the
+//     SDK nor the cases above recognize.
+//
+// A missing bucket is deliberately not in that list even though it is also a
+// 404. It is a configuration error, not a missing file: a caller told
+// fs.ErrNotExist would conclude the object was never written, when in fact
+// nothing at all can be read or written.
 func errIsNotExist(err error) bool {
 	var notFoundErr *types.NotFound
 	if errors.As(err, &notFoundErr) {
 		return true
 	}
 	var noKeyErr *types.NoSuchKey
-	return errors.As(err, &noKeyErr)
+	if errors.As(err, &noKeyErr) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NoSuchKey", "NotFound":
+			return true
+		case "NoSuchBucket":
+			return false
+		}
+	}
+	var respErr *smithyhttp.ResponseError
+	return errors.As(err, &respErr) && respErr.HTTPStatusCode() == http.StatusNotFound
+}
+
+// notExistErr wraps err so that errors.Is(err, fs.ErrNotExist) matches while
+// the cause stays reachable. Replacing the cause with fs.ErrNotExist -- what
+// this package used to do -- throws away the status code, the request ID and
+// the API error code, which is most of what makes a failure against a real
+// endpoint diagnosable.
+func notExistErr(err error) error {
+	return fmt.Errorf("%w: %w", fs.ErrNotExist, err)
 }


### PR DESCRIPTION
Two of the mock's answers did not match a real endpoint's, and both hid a
defect in the s3 backend.

DeleteObject returned NoSuchKey for a key the bucket did not hold. A real
endpoint answers 204 whether or not the key was there and reports nothing
about which it was -- that idempotency is exactly what makes the backend's
Remove unable to tell a missing key from a deleted one. The mock's opposite
behavior made Remove look strict under test while returning nil in
production. It now deletes unconditionally, still recording the key it
targeted, and still refusing a request naming the wrong bucket.

A missing-key lookup returned a bare *types.NoSuchKey from every operation.
A real one comes back as the operation's own typed error inside the
*smithyhttp.ResponseError carrying the 404, inside the AWS transport's
ResponseError carrying the request ID -- and the typed error differs by
operation: HeadObject has no response body, so the SDK derives the code from
the status and deserializes *types.NotFound, while GetObject, CopyObject and
UploadPartCopy read NoSuchKey out of the body. An S3-compatible store whose
code the SDK cannot resolve to a type produces a *smithy.GenericAPIError
carrying the code as a string instead, so the shape is selectable:

	mock.New(bucket)                                             // real-S3
	mock.New(bucket).WithNotFoundStyle(mock.NotFoundStyleGeneric) // generic

Contrary to the issue's expectation, this does not turn CI red on its own.
The AWS-style shape keeps the typed error reachable through errors.As, so
errIsNotExist still matches it, and the one assertion that would have failed
-- Remove of a missing key -- is skipped in imptest pending its fix. Both
defects are real and reproduce against the corrected mock; the next two
commits fix them and turn on the assertions that catch them:

  Remove("missing.txt")                       => nil, want fs.ErrNotExist
  OpenFile("missing.txt") // generic style    => opaque 404 API error,
                                                 want fs.ErrNotExist

Refs #166

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AXEU5UFn1kPMGpiZGkzjV5