### PR TITLE
Copy strategy based on source size, not CopyObject failure

### DIFF
--- a/fs/s3/doc.go
+++ b/fs/s3/doc.go
@@ -40,6 +40,12 @@
 //     write at PartSize x 10,000 -- about 48 GiB at the SDK's default, which
 //     [WithUploaderOptions] can raise.
 //
+//   - [BucketFS.Copy] decides its strategy from the source's HEAD
+//     ContentLength rather than by trying a copy and inspecting the failure:
+//     a source of 5 GiB or less -- CopyObject's own limit -- is copied with
+//     one request, and a larger one is copied part by part with
+//     [MultiCopier].
+//
 //   - A missing key is reported as an error satisfying errors.Is(err,
 //     fs.ErrNotExist) whatever shape the store's error arrived in -- a typed
 //     SDK error, an API error code, or a bare 404 -- with the original error

--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -102,6 +102,14 @@ func (f *BucketFS) WriteWithOptions(ctx context.Context, name string, r io.Reade
 	return write(ctx, f.uploader, f.bucket, name, r, opts...)
 }
 
+// Copy copies the object at src to dst within the bucket, per [ocflfs.CopyFS].
+//
+// The strategy is chosen from src's HEAD ContentLength, not by trying a copy
+// and inspecting the failure: a source of 5 GiB or less is copied with one
+// CopyObject request, and a larger one is copied part by part with
+// [MultiCopier], tunable through [WithMultiPartCopyOption]. A store that
+// enforces a smaller CopyObject limit than 5 GiB returns that store's error
+// rather than falling back to MultiCopier.
 func (f *BucketFS) Copy(ctx context.Context, dst, src string) (int64, error) {
 	f.debugLog(ctx, "s3:copy", "bucket", f.bucket, "dst", dst, "src", src)
 	return copy(ctx, f.client, f.bucket, dst, src, f.multiPartCopyOptions...)

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -754,8 +755,6 @@ func TestRemoveAll_Mock(t *testing.T) {
 
 func TestCopy_Mock(t *testing.T) {
 	ctx := context.Background()
-	srcSize := int64(51 * megabyte)
-	srcBody := mock.RandBytes(srcSize)
 	type testCase struct {
 		desc      string
 		mock      func(t *testing.T) *mock.S3API
@@ -783,30 +782,38 @@ func TestCopy_Mock(t *testing.T) {
 				be.Nonzero(t, state.UpdatedETag("dst-file"))
 				be.Nonzero(t, size)
 				be.Equal(t, 0, state.PartCount())
+				// A source well under the CopyObject limit takes the
+				// single-request path: no doomed CopyObject followed by a
+				// fallback, and no multipart machinery at all.
+				be.Equal(t, 1, state.CallCount("CopyObject"))
+				be.Equal(t, 0, state.CallCount("CreateMultipartUpload"))
 			},
 		}, {
-			desc: "multipart copy",
+			// copy no longer tries CopyObject and inspects the failure text
+			// to decide whether to fall back to MultiCopier -- the strategy
+			// is chosen up front from the HEAD size. This case pins that
+			// removal: even an error worded exactly like the old "copy
+			// source is larger than the maximum allowable size" trigger
+			// must now propagate as-is, on a source well under the 5 GiB
+			// threshold that would otherwise pick MultiCopier on size alone.
+			desc: "CopyObject failure is returned as-is, no error-text fallback",
 			mock: func(t *testing.T) *mock.S3API {
 				api := mock.New(bucket, &mock.Object{
 					Key:  "src-file",
-					Body: srcBody,
+					Body: []byte("some content"),
 				})
-				// override the default CopyObject method to return
-				// the necessary error for initiating multipart copy
 				api.CopyObjectFunc = func(_ context.Context, _ *s3v2.CopyObjectInput, _ ...func(*s3v2.Options)) (*s3v2.CopyObjectOutput, error) {
 					return nil, errors.New("copy source is larger than the maximum allowable size")
 				}
 				return api
 			},
-			bucket:    bucket,
-			src:       "src-file",
-			dst:       "dst-file",
-			copyPSize: partSize,
+			bucket: bucket,
+			src:    "src-file",
+			dst:    "dst-file",
 			expect: func(t *testing.T, state *mock.S3API, size int64, err error) {
-				be.NilErr(t, err)
-				be.Nonzero(t, size)
-				expETag := mock.ETag(srcBody, partSize)
-				be.Equal(t, expETag, state.UpdatedETag("dst-file"))
+				be.Nonzero(t, err)
+				be.Equal(t, int64(0), size)
+				be.Equal(t, 0, state.CallCount("CreateMultipartUpload"))
 			},
 		},
 	}
@@ -826,6 +833,136 @@ func TestCopy_Mock(t *testing.T) {
 			tcase.expect(t, api, size, err)
 		})
 	}
+}
+
+// TestMultiCopier_Mock drives MultiCopier.Copy directly -- range slicing,
+// per-part ETags, CompleteMultipartUpload -- against the mock's real
+// validation. copy no longer reaches MultiCopier through a CopyObject
+// failure text match (that fallback is gone, see TestCopy_Mock); this is
+// where the multipart mechanics stay covered end to end.
+func TestMultiCopier_Mock(t *testing.T) {
+	ctx := context.Background()
+	srcSize := int64(51 * megabyte)
+	srcBody := mock.RandBytes(srcSize)
+	api := mock.New(bucket, &mock.Object{Key: "src-file", Body: srcBody})
+	copier := s3.NewMultiCopier(api, func(mc *s3.MultiCopier) {
+		mc.PartSize = partSize
+	})
+	size, err := copier.Copy(ctx, bucket, "dst-file", "src-file")
+	be.NilErr(t, err)
+	be.Equal(t, srcSize, size)
+	expETag := mock.ETag(srcBody, partSize)
+	be.Equal(t, expETag, api.UpdatedETag("dst-file"))
+	be.Nonzero(t, api.PartCount())
+}
+
+// sizedCopyAPI is the mock with HeadObject's ContentLength overridden, so a
+// test can drive copy's size-based strategy choice for a source far larger
+// than anything actually worth allocating. UploadPartCopy and
+// CompleteMultipartUpload are replaced rather than delegated: the mock's
+// real versions slice the actual (tiny) stored body by the declared range
+// and validate each part's ETag against ones its own UploadPartCopy stored,
+// neither of which holds once the size is faked.
+type sizedCopyAPI struct {
+	*mock.S3API
+	// size replaces HeadObject's ContentLength on the src-file response. A
+	// negative size instead sets ContentLength to nil, so a test can drive
+	// the missing-content-length guard without a store that actually omits
+	// it.
+	size int64
+
+	mu     sync.Mutex
+	ranges []string // CopySourceRange values UploadPartCopy was called with
+}
+
+func (a *sizedCopyAPI) HeadObject(ctx context.Context, in *s3v2.HeadObjectInput,
+	opts ...func(*s3v2.Options)) (*s3v2.HeadObjectOutput, error) {
+	out, err := a.S3API.HeadObject(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if a.size < 0 {
+		out.ContentLength = nil
+	} else {
+		out.ContentLength = aws.Int64(a.size)
+	}
+	return out, nil
+}
+
+func (a *sizedCopyAPI) UploadPartCopy(ctx context.Context, in *s3v2.UploadPartCopyInput,
+	opts ...func(*s3v2.Options)) (*s3v2.UploadPartCopyOutput, error) {
+	a.mu.Lock()
+	a.ranges = append(a.ranges, aws.ToString(in.CopySourceRange))
+	a.mu.Unlock()
+	return &s3v2.UploadPartCopyOutput{
+		CopyPartResult: &types.CopyPartResult{ETag: aws.String(fmt.Sprintf("etag-%d", aws.ToInt32(in.PartNumber)))},
+	}, nil
+}
+
+func (a *sizedCopyAPI) CompleteMultipartUpload(ctx context.Context, in *s3v2.CompleteMultipartUploadInput,
+	opts ...func(*s3v2.Options)) (*s3v2.CompleteMultipartUploadOutput, error) {
+	a.S3API.MPUComplete = true
+	return &s3v2.CompleteMultipartUploadOutput{Bucket: in.Bucket, Key: in.Key}, nil
+}
+
+// TestCopyStrategy_Mock covers the behavior change directly: the strategy is
+// read from the source's HEAD size, not discovered by trying CopyObject and
+// inspecting the failure.
+func TestCopyStrategy_Mock(t *testing.T) {
+	ctx := context.Background()
+	const maxCopySize = 5 * 1024 * int64(megabyte) // CopyObject's own limit
+
+	t.Run("exactly the limit takes the single-request path", func(t *testing.T) {
+		base := mock.New(bucket, &mock.Object{Key: "src-file", Body: []byte("some content")})
+		api := &sizedCopyAPI{S3API: base, size: maxCopySize}
+		fsys := s3.NewBucketFS(api, bucket)
+		size, err := fsys.Copy(ctx, "dst-file", "src-file")
+		be.NilErr(t, err)
+		be.Equal(t, maxCopySize, size)
+		be.Equal(t, 1, api.CallCount("CopyObject"))
+		be.Equal(t, 0, api.CallCount("CreateMultipartUpload"))
+	})
+
+	t.Run("one byte over the limit takes the multipart path", func(t *testing.T) {
+		base := mock.New(bucket, &mock.Object{Key: "src-file", Body: []byte("some content")})
+		api := &sizedCopyAPI{S3API: base, size: maxCopySize + 1}
+		fsys := s3.NewBucketFS(api, bucket)
+		size, err := fsys.Copy(ctx, "dst-file", "src-file")
+		be.NilErr(t, err)
+		be.Equal(t, maxCopySize+1, size)
+		// The point of the change: no CopyObject is attempted at all, let
+		// alone one that is left to fail first.
+		be.Equal(t, 0, api.CallCount("CopyObject"))
+		be.Equal(t, 1, api.CallCount("CreateMultipartUpload"))
+		be.True(t, api.MPUCompleteFlag())
+
+		// The parts must tile [0, size) with no gap or overlap.
+		type span struct{ start, end int64 }
+		spans := make([]span, len(api.ranges))
+		for i, r := range api.ranges {
+			var sp span
+			n, err := fmt.Sscanf(r, "bytes=%d-%d", &sp.start, &sp.end)
+			be.NilErr(t, err)
+			be.Equal(t, 2, n)
+			spans[i] = sp
+		}
+		sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+		var next int64
+		for _, sp := range spans {
+			be.Equal(t, next, sp.start)
+			next = sp.end + 1
+		}
+		be.Equal(t, maxCopySize+1, next)
+	})
+
+	t.Run("nil ContentLength is refused, not dereferenced", func(t *testing.T) {
+		base := mock.New(bucket, &mock.Object{Key: "src-file", Body: []byte("some content")})
+		api := &sizedCopyAPI{S3API: base, size: -1}
+		fsys := s3.NewBucketFS(api, bucket)
+		_, err := fsys.Copy(ctx, "dst-file", "src-file")
+		be.Nonzero(t, err)
+		be.Equal(t, 0, api.CallCount("CopyObject"))
+	})
 }
 
 func TestSameBackend_Mock(t *testing.T) {

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -27,15 +27,19 @@ const (
 	megabyte          int64 = 1024 * 1024
 	partSizeIncrement       = 1 * megabyte
 
-	// error message returned when copy fails because source is too large: used
-	// to trigger multipart upload. (This appears to be the only way to check
-	// this error).
-	copySrcTooLarge = "copy source is larger than the maximum allowable size"
-
 	// modes retured by Stat()
 	fileMode = 0644 | fs.ModeIrregular
 	dirMode  = 0755 | fs.ModeDir
 )
+
+// maxCopySize is the largest source CopyObject accepts. It is a fixed S3 API
+// limit, not a tunable: a source larger than this has to be copied part by
+// part, which is what MultiCopier does. copy compares the source's HEAD
+// ContentLength against it rather than issuing a CopyObject to find out, so a
+// large copy costs no doomed request and the choice does not depend on how a
+// store words its error. A store that enforces a smaller limit than this one
+// fails rather than falling back -- see [BucketFS.Copy].
+const maxCopySize int64 = 5 * 1024 * megabyte
 
 // maxDeleteBatch is the most keys DeleteObjects accepts in one request. It is
 // a fixed S3 API limit, not a tunable: a larger request is rejected outright.
@@ -182,6 +186,18 @@ func copy(ctx context.Context, api CopyAPI, buck string, dst, src string, opts .
 		}
 		return 0, pathErr("copy", src, err)
 	}
+	// The size decides the strategy, and the HEAD above already carries it.
+	// A store may omit ContentLength on a HEAD response; refusing here is
+	// better than carrying an unknown size into a choice that depends on it.
+	if srcHead.ContentLength == nil {
+		return 0, pathErr("copy", src, errors.New("missing content length"))
+	}
+	srcSize := *srcHead.ContentLength
+	if srcSize > maxCopySize {
+		// too large for CopyObject: copy it part by part instead. The HEAD is
+		// handed on so MultiCopier does not repeat it.
+		return NewMultiCopier(api, opts...).Copy(ctx, buck, dst, src, srcHead)
+	}
 	escapedSrc := url.QueryEscape(buck + "/" + src)
 	params := &s3.CopyObjectInput{
 		Bucket:     &buck,
@@ -189,16 +205,9 @@ func copy(ctx context.Context, api CopyAPI, buck string, dst, src string, opts .
 		Key:        &dst,
 	}
 	if _, err := api.CopyObject(ctx, params); err != nil {
-		// if the source is too large, try multipart copy.
-		// this error doesn't seem to have a specific type
-		// associated with it.
-		if strings.Contains(err.Error(), copySrcTooLarge) {
-			// source is too large for basic copy -- try multipart copy
-			return NewMultiCopier(api, opts...).Copy(ctx, buck, dst, src, srcHead)
-		}
 		return 0, pathErr("copy", src, err)
 	}
-	return *srcHead.ContentLength, nil
+	return srcSize, nil
 }
 
 func remove(ctx context.Context, api RemoveAPI, b string, name string) error {


### PR DESCRIPTION
## Summary

Changed the S3 copy operation to determine whether to use single-request `CopyObject` or multipart `MultiCopier` based on the source's HEAD ContentLength, rather than attempting `CopyObject` first and inspecting error messages to decide on fallback.

## Key Changes

- **Strategy selection moved to size-based decision**: The copy operation now checks if the source size exceeds 5 GiB (S3's `CopyObject` limit) before attempting any copy, eliminating the need to try `CopyObject` and parse error messages.

- **Removed error-text matching**: Deleted the `copySrcTooLarge` constant and the logic that matched against "copy source is larger than the maximum allowable size" error text to trigger multipart fallback.

- **Added ContentLength validation**: The copy operation now explicitly checks that `HeadObject` returns a non-nil `ContentLength`, refusing to proceed if it's missing rather than dereferencing a nil pointer.

- **Introduced `maxCopySize` constant**: Defined as 5 GiB, this constant is now used to make the strategy decision upfront. Stores enforcing smaller limits will have their errors propagated as-is rather than triggering a fallback.

- **Refactored test coverage**: 
  - Modified `TestCopy_Mock` to remove the multipart copy test case and add assertions verifying the single-request path
  - Added `TestMultiCopier_Mock` to directly test `MultiCopier.Copy` mechanics (range slicing, part ETags, completion)
  - Added `TestCopyStrategy_Mock` with a new `sizedCopyAPI` mock to verify size-based strategy selection without allocating large test data

- **Updated documentation**: Added docstring to `BucketFS.Copy` explaining the new strategy selection behavior and updated `doc.go` to document the change.

## Implementation Details

- The `copy` function now calls `NewMultiCopier` directly when `srcSize > maxCopySize`, passing the already-fetched `srcHead` to avoid redundant HEAD requests.
- The `sizedCopyAPI` test helper overrides `HeadObject` to inject custom sizes and stubs `UploadPartCopy`/`CompleteMultipartUpload` to avoid needing actual large test data.
- No functional change to the actual copy mechanics—only the decision point has moved earlier and is now deterministic based on size rather than error inspection.

https://claude.ai/code/session_01WtuqaAWj1DySU1WSxDg7Sd