### PR TITLE
Fix S3 copy-source header encoding for special characters

### DIFF
--- a/fs/s3/copysource.go
+++ b/fs/s3/copysource.go
@@ -1,0 +1,62 @@
+package s3
+
+import "strings"
+
+// unreservedCopySource reports whether b may appear literally in the
+// x-amz-copy-source header. It is the RFC 3986 unreserved set plus "/",
+// which S3 needs literal: once to separate the bucket from the key, and
+// again for every directory separator within the key.
+func unreservedCopySource(b byte) bool {
+	switch {
+	case 'A' <= b && b <= 'Z', 'a' <= b && b <= 'z', '0' <= b && b <= '9':
+		return true
+	}
+	switch b {
+	case '-', '_', '.', '~', '/':
+		return true
+	}
+	return false
+}
+
+const upperhex = "0123456789ABCDEF"
+
+// encodeCopySource builds the value for the x-amz-copy-source header:
+// "<bucket>/<key>" with "/" left literal and every other byte outside the
+// RFC 3986 unreserved set percent-encoded.
+//
+// net/url has no function with these semantics. QueryEscape encodes "/" as
+// %2F -- destroying both the bucket/key separator and every path separator
+// in the key -- and writes a space as "+", which S3 reads literally.
+// PathEscape encodes "/" too. The AWS SDK does not encode the value for us:
+// it sets the header verbatim and documents that "the value must be
+// URL-encoded", leaving the encoding to the caller.
+//
+// key must be a raw OCFL path, never an already-encoded one: "%" is itself
+// encoded, so encoding twice yields the wrong key.
+func encodeCopySource(bucket, key string) string {
+	src := bucket + "/" + key
+	// Iterate bytes, not runes: each byte of a multi-byte UTF-8 rune becomes
+	// its own %XX, which is what S3 expects.
+	n := 0
+	for i := range len(src) {
+		if !unreservedCopySource(src[i]) {
+			n++
+		}
+	}
+	if n == 0 {
+		return src
+	}
+	var b strings.Builder
+	b.Grow(len(src) + 2*n)
+	for i := range len(src) {
+		c := src[i]
+		if unreservedCopySource(c) {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('%')
+		b.WriteByte(upperhex[c>>4])
+		b.WriteByte(upperhex[c&0x0f])
+	}
+	return b.String()
+}

--- a/fs/s3/copysource_test.go
+++ b/fs/s3/copysource_test.go
@@ -1,0 +1,75 @@
+package s3
+
+import "testing"
+
+func TestEncodeCopySource(t *testing.T) {
+	cases := []struct {
+		desc        string
+		bucket, key string
+		expect      string
+	}{
+		{
+			desc:   "plain key",
+			bucket: "my-bucket",
+			key:    "object.txt",
+			expect: "my-bucket/object.txt",
+		},
+		{
+			desc:   "nested slashes preserved literally",
+			bucket: "my-bucket",
+			key:    "a/b/c/object.txt",
+			expect: "my-bucket/a/b/c/object.txt",
+		},
+		{
+			desc:   "space encodes to %20, not +",
+			bucket: "my-bucket",
+			key:    "a file.txt",
+			expect: "my-bucket/a%20file.txt",
+		},
+		{
+			desc:   "plus encodes to %2B",
+			bucket: "my-bucket",
+			key:    "a+b.txt",
+			expect: "my-bucket/a%2Bb.txt",
+		},
+		{
+			desc:   "non-ASCII encodes per UTF-8 byte, uppercase hex",
+			bucket: "my-bucket",
+			key:    "café.txt",
+			// 'é' is the two UTF-8 bytes 0xC3 0xA9.
+			expect: "my-bucket/caf%C3%A9.txt",
+		},
+		{
+			desc:   "CJK characters encode per UTF-8 byte",
+			bucket: "my-bucket",
+			key:    "日本語.txt",
+			expect: "my-bucket/%E6%97%A5%E6%9C%AC%E8%AA%9E.txt",
+		},
+		{
+			desc:   "unreserved punctuation left alone",
+			bucket: "my-bucket",
+			key:    "a-b_c.d~e",
+			expect: "my-bucket/a-b_c.d~e",
+		},
+		{
+			desc:   "percent sign encodes to %25 (no double-encoding)",
+			bucket: "my-bucket",
+			key:    "100%done.txt",
+			expect: "my-bucket/100%25done.txt",
+		},
+		{
+			desc:   "empty key",
+			bucket: "my-bucket",
+			key:    "",
+			expect: "my-bucket/",
+		},
+	}
+	for _, tcase := range cases {
+		t.Run(tcase.desc, func(t *testing.T) {
+			got := encodeCopySource(tcase.bucket, tcase.key)
+			if got != tcase.expect {
+				t.Errorf("encodeCopySource(%q, %q) = %q, want %q", tcase.bucket, tcase.key, got, tcase.expect)
+			}
+		})
+	}
+}

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -157,10 +157,10 @@ func TestWriteReadDeleteFile(t *testing.T) {
 }
 
 // TestCopySpecialCharacters is the mock cases' counterpart against a real
-// endpoint for #167 item 3: it proves the copy-source header is encoded
-// correctly for keys a bug in url.QueryEscape would corrupt or misroute --
-// a space, a "+", non-ASCII characters, and a nested path -- since the mock
-// alone cannot prove what a real bucket does with the header.
+// endpoint: it proves the copy-source header is encoded correctly for keys
+// a bug in url.QueryEscape would corrupt or misroute -- a space, a "+",
+// non-ASCII characters, and a nested path -- since the mock alone cannot
+// prove what a real bucket does with the header.
 func TestCopySpecialCharacters(t *testing.T) {
 	if !testutil.S3Enabled() {
 		t.Log("s3 test service is not running")
@@ -855,12 +855,12 @@ func TestCopy_Mock(t *testing.T) {
 				be.Equal(t, 0, state.CallCount("CreateMultipartUpload"))
 			},
 		}, {
-			// regression test for #167 item 3: the copy-source header was
-			// built with url.QueryEscape, which encodes "/" as %2F
-			// (destroying path separators) and space as "+" (which S3
-			// reads literally). The mock's CopyObject splits the header on
-			// a literal "/" before percent-decoding, the same way a real
-			// bucket does, so it rejects that encoding on its own.
+			// regression test: the copy-source header was built with
+			// url.QueryEscape, which encodes "/" as %2F (destroying path
+			// separators) and space as "+" (which S3 reads literally). The
+			// mock's CopyObject splits the header on a literal "/" before
+			// percent-decoding, the same way a real bucket does, so it
+			// rejects that encoding on its own.
 			desc: "copy with space and nested path in source key",
 			mock: func(t *testing.T) *mock.S3API {
 				return mock.New(bucket, &mock.Object{
@@ -956,10 +956,10 @@ func TestMultiCopier_Mock(t *testing.T) {
 }
 
 // TestMultiCopierSpecialCharacters_Mock is TestMultiCopier_Mock's
-// counterpart for #167 item 3: it drives MultiCopier.Copy directly with a
-// source key containing a space and non-ASCII characters, exercising the
-// UploadPartCopy call site's copy-source encoding independently of copy()'s
-// CopyObject path.
+// counterpart for special characters in the source key: it drives
+// MultiCopier.Copy directly with a source key containing a space and
+// non-ASCII characters, exercising the UploadPartCopy call site's
+// copy-source encoding independently of copy()'s CopyObject path.
 func TestMultiCopierSpecialCharacters_Mock(t *testing.T) {
 	ctx := context.Background()
 	srcSize := int64(51 * megabyte)

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -156,6 +156,45 @@ func TestWriteReadDeleteFile(t *testing.T) {
 	be.NilErr(t, fsys.Remove(ctx, key))
 }
 
+// TestCopySpecialCharacters is the mock cases' counterpart against a real
+// endpoint for #167 item 3: it proves the copy-source header is encoded
+// correctly for keys a bug in url.QueryEscape would corrupt or misroute --
+// a space, a "+", non-ASCII characters, and a nested path -- since the mock
+// alone cannot prove what a real bucket does with the header.
+func TestCopySpecialCharacters(t *testing.T) {
+	if !testutil.S3Enabled() {
+		t.Log("s3 test service is not running")
+		return
+	}
+	ctx := t.Context()
+	fsys := testutil.TmpS3FS(t, nil)
+	cases := []struct {
+		desc string
+		src  string
+		dst  string
+	}{
+		{desc: "space in nested key", src: "dir/sub dir/a file.txt", dst: "dst-dir/a file.txt"},
+		{desc: "plus in key", src: "a+b.txt", dst: "dst+c.txt"},
+		{desc: "non-ASCII key", src: "café/日本語.txt", dst: "dst-café.txt"},
+	}
+	for _, tcase := range cases {
+		t.Run(tcase.desc, func(t *testing.T) {
+			buff := mock.RandBytes(1024)
+			_, err := fsys.Write(ctx, tcase.src, bytes.NewReader(buff))
+			be.NilErr(t, err)
+			size, err := fsys.Copy(ctx, tcase.dst, tcase.src)
+			be.NilErr(t, err)
+			be.Equal(t, len(buff), int(size))
+			f, err := fsys.OpenFile(ctx, tcase.dst)
+			be.NilErr(t, err)
+			defer f.Close()
+			got, err := io.ReadAll(f)
+			be.NilErr(t, err)
+			be.True(t, bytes.Equal(buff, got))
+		})
+	}
+}
+
 // TestWritePartialReader is the mock cases' counterpart against a real
 // endpoint, where a wrongly declared Content-Length fails before the request
 // leaves the client.
@@ -815,6 +854,66 @@ func TestCopy_Mock(t *testing.T) {
 				be.Equal(t, int64(0), size)
 				be.Equal(t, 0, state.CallCount("CreateMultipartUpload"))
 			},
+		}, {
+			// regression test for #167 item 3: the copy-source header was
+			// built with url.QueryEscape, which encodes "/" as %2F
+			// (destroying path separators) and space as "+" (which S3
+			// reads literally). The mock's CopyObject splits the header on
+			// a literal "/" before percent-decoding, the same way a real
+			// bucket does, so it rejects that encoding on its own.
+			desc: "copy with space and nested path in source key",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket, &mock.Object{
+					Key:  "dir/sub dir/a file.txt",
+					Body: []byte("some content"),
+				})
+			},
+			bucket: bucket,
+			src:    "dir/sub dir/a file.txt",
+			dst:    "dir2/a file.txt",
+			expect: func(t *testing.T, state *mock.S3API, size int64, err error) {
+				be.NilErr(t, err)
+				be.Nonzero(t, state.UpdatedETag("dir2/a file.txt"))
+				be.Nonzero(t, size)
+				be.Equal(t, 1, state.CallCount("CopyObject"))
+				be.Equal(t, 0, state.CallCount("CreateMultipartUpload"))
+			},
+		}, {
+			desc: "copy with plus in source key",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket, &mock.Object{
+					Key:  "a+b.txt",
+					Body: []byte("some content"),
+				})
+			},
+			bucket: bucket,
+			src:    "a+b.txt",
+			dst:    "dst+c.txt",
+			expect: func(t *testing.T, state *mock.S3API, size int64, err error) {
+				be.NilErr(t, err)
+				be.Nonzero(t, state.UpdatedETag("dst+c.txt"))
+				be.Nonzero(t, size)
+				be.Equal(t, 1, state.CallCount("CopyObject"))
+				be.Equal(t, 0, state.CallCount("CreateMultipartUpload"))
+			},
+		}, {
+			desc: "copy with non-ASCII source key",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket, &mock.Object{
+					Key:  "café/日本語.txt",
+					Body: []byte("some content"),
+				})
+			},
+			bucket: bucket,
+			src:    "café/日本語.txt",
+			dst:    "dst-café.txt",
+			expect: func(t *testing.T, state *mock.S3API, size int64, err error) {
+				be.NilErr(t, err)
+				be.Nonzero(t, state.UpdatedETag("dst-café.txt"))
+				be.Nonzero(t, size)
+				be.Equal(t, 1, state.CallCount("CopyObject"))
+				be.Equal(t, 0, state.CallCount("CreateMultipartUpload"))
+			},
 		},
 	}
 	for i, tcase := range cases {
@@ -853,6 +952,29 @@ func TestMultiCopier_Mock(t *testing.T) {
 	be.Equal(t, srcSize, size)
 	expETag := mock.ETag(srcBody, partSize)
 	be.Equal(t, expETag, api.UpdatedETag("dst-file"))
+	be.Nonzero(t, api.PartCount())
+}
+
+// TestMultiCopierSpecialCharacters_Mock is TestMultiCopier_Mock's
+// counterpart for #167 item 3: it drives MultiCopier.Copy directly with a
+// source key containing a space and non-ASCII characters, exercising the
+// UploadPartCopy call site's copy-source encoding independently of copy()'s
+// CopyObject path.
+func TestMultiCopierSpecialCharacters_Mock(t *testing.T) {
+	ctx := context.Background()
+	srcSize := int64(51 * megabyte)
+	srcBody := mock.RandBytes(srcSize)
+	const src = "dir/a file+é.txt"
+	const dst = "dst/a file+é.txt"
+	api := mock.New(bucket, &mock.Object{Key: src, Body: srcBody})
+	copier := s3.NewMultiCopier(api, func(mc *s3.MultiCopier) {
+		mc.PartSize = partSize
+	})
+	size, err := copier.Copy(ctx, bucket, dst, src)
+	be.NilErr(t, err)
+	be.Equal(t, srcSize, size)
+	expETag := mock.ETag(srcBody, partSize)
+	be.Equal(t, expETag, api.UpdatedETag(dst))
 	be.Nonzero(t, api.PartCount())
 }
 

--- a/fs/s3/internal/mock/mock.go
+++ b/fs/s3/internal/mock/mock.go
@@ -336,11 +336,10 @@ func (m *S3API) UploadPartCopy(ctx context.Context, in *s3v2.UploadPartCopyInput
 	if in.CopySource == nil {
 		return nil, errors.New("CopySource is required")
 	}
-	copySourceDecoded, err := url.QueryUnescape(*in.CopySource)
+	srcBucket, srcKey, err := parseCopySource(*in.CopySource)
 	if err != nil {
 		return nil, fmt.Errorf("parsing copy source: %w", err)
 	}
-	srcBucket, srcKey, _ := strings.Cut(copySourceDecoded, "/")
 	if srcBucket != m.bucket {
 		return nil, &types.NoSuchBucket{}
 	}
@@ -451,11 +450,10 @@ func (m *S3API) CopyObject(ctx context.Context, in *s3v2.CopyObjectInput, opts .
 	if in.CopySource == nil {
 		return nil, errors.New("CopySource is required")
 	}
-	copySourceDecoded, err := url.QueryUnescape(*in.CopySource)
+	srcBucket, srcKey, err := parseCopySource(*in.CopySource)
 	if err != nil {
 		return nil, fmt.Errorf("parsing copy source: %w", err)
 	}
-	srcBucket, srcKey, _ := strings.Cut(copySourceDecoded, "/")
 	if srcBucket != m.bucket {
 		return nil, &types.NoSuchBucket{}
 	}
@@ -756,6 +754,25 @@ func eql[T comparable](expect T, ptr *T) bool {
 		return false
 	}
 	return *ptr == expect
+}
+
+// parseCopySource splits an x-amz-copy-source header value into bucket and
+// key, mirroring how S3 actually parses it: split at the first literal "/",
+// then percent-decode the key. This matters for testing the caller's
+// encoding -- a caller that (wrongly) escapes "/" as %2F produces a value
+// with no literal slash, which fails the split here exactly as it would
+// against a real bucket, rather than silently decoding back to the
+// original path.
+func parseCopySource(copySource string) (bucket, key string, err error) {
+	bucket, encodedKey, ok := strings.Cut(copySource, "/")
+	if !ok {
+		return "", "", fmt.Errorf("missing bucket/key separator in copy source: %q", copySource)
+	}
+	key, err = url.PathUnescape(encodedKey)
+	if err != nil {
+		return "", "", err
+	}
+	return bucket, key, nil
 }
 
 func parseByteRange(brange string) (start int64, end int64, err error) {

--- a/fs/s3/multicopy.go
+++ b/fs/s3/multicopy.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"context"
 	"errors"
-	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -100,7 +99,7 @@ func (c *MultiCopier) Copy(ctx context.Context, buck string, dst, src string, sr
 	}()
 	grp, grpCtx := errgroup.WithContext(ctx)
 	grp.SetLimit(c.Concurrency)
-	copySource := url.QueryEscape(buck + "/" + src)
+	copySource := encodeCopySource(buck, src)
 	for i := range partCount {
 		grp.Go(func() error {
 			var err error

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"iter"
 	"net/http"
-	"net/url"
 	"path"
 	"slices"
 	"strings"
@@ -198,10 +197,10 @@ func copy(ctx context.Context, api CopyAPI, buck string, dst, src string, opts .
 		// handed on so MultiCopier does not repeat it.
 		return NewMultiCopier(api, opts...).Copy(ctx, buck, dst, src, srcHead)
 	}
-	escapedSrc := url.QueryEscape(buck + "/" + src)
+	escapedSrc := encodeCopySource(buck, src)
 	params := &s3.CopyObjectInput{
 		Bucket:     &buck,
-		CopySource: &escapedSrc, // value must be URL-encoded
+		CopySource: &escapedSrc, // percent-encoded per encodeCopySource
 		Key:        &dst,
 	}
 	if _, err := api.CopyObject(ctx, params); err != nil {


### PR DESCRIPTION
## Summary
Fixes incorrect encoding of the `x-amz-copy-source` header when copying S3 objects with special characters in their keys (spaces, plus signs, non-ASCII characters, and nested paths).

## Problem
The code was using `url.QueryEscape()` to encode the copy-source header value, which has two critical issues:
1. Encodes "/" as "%2F", destroying both the bucket/key separator and path separators within keys
2. Encodes spaces as "+", which S3 reads literally instead of as a space character

This caused copy operations to fail for keys containing spaces, plus signs, non-ASCII characters, or nested directories.

## Solution
- **New `encodeCopySource()` function** in `fs/s3/copysource.go`: Implements correct percent-encoding for the copy-source header by:
  - Preserving "/" literally (for bucket/key separator and path separators)
  - Encoding spaces as "%20" (not "+")
  - Encoding all other special characters per RFC 3986 unreserved set
  - Properly handling UTF-8 multi-byte characters (each byte encoded separately)

- **Updated call sites** in `s3.go` and `multicopy.go` to use `encodeCopySource()` instead of `url.QueryEscape()`

- **Enhanced mock S3 API** in `internal/mock/mock.go`:
  - New `parseCopySource()` function that mirrors real S3 behavior: splits on first literal "/" then percent-decodes
  - This validates that callers encode correctly (wrong encoding produces no literal "/" and fails the split)
  - Updated `CopyObject()` and `UploadPartCopy()` to use the new parser

- **Comprehensive test coverage**:
  - `TestCopySpecialCharacters()`: Integration test against real S3 endpoint with spaces, plus signs, non-ASCII, and nested paths
  - `TestCopy_Mock()`: Three new mock test cases for the same scenarios
  - `TestMultiCopierSpecialCharacters_Mock()`: Tests multipart copy path with special characters
  - `TestEncodeCopySource()`: Unit tests for the encoding function with edge cases

## Key Implementation Details
- The encoding function iterates over bytes (not runes) so multi-byte UTF-8 sequences are encoded byte-by-byte, matching S3's expectations
- Unreserved characters (alphanumerics, `-`, `_`, `.`, `~`, `/`) are left literal
- The mock's `parseCopySource()` validates correct encoding by requiring a literal "/" separator before percent-decoding, catching encoding mistakes that would pass through a naive decoder

https://claude.ai/code/session_01MEvwZihgTxyqJpeL75MPr7