### PR TITLE
Validate ContentLength and LastModified in HEAD responses

### DIFF
--- a/fs/s3/doc.go
+++ b/fs/s3/doc.go
@@ -46,6 +46,12 @@
 //     one request, and a larger one is copied part by part with
 //     [MultiCopier].
 //
+//   - [BucketFS.OpenFile] and [BucketFS.Copy] both resolve the source's size
+//     from a HEAD response's ContentLength, which the AWS SDK models as
+//     *int64 because some stores and reverse proxies omit it. Either call
+//     refuses with an error rather than carrying an unknown size into Stat,
+//     Read, Seek, or the copy strategy choice.
+//
 //   - A missing key is reported as an error satisfying errors.Is(err,
 //     fs.ErrNotExist) whatever shape the store's error arrived in -- a typed
 //     SDK error, an API error code, or a bare 404 -- with the original error

--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -71,6 +71,12 @@ func (f *BucketFS) Bucket() string {
 	return f.bucket
 }
 
+// OpenFile opens the object at name for reading, per [ocflfs.FS].
+//
+// A HEAD request resolves the object's size and mtime up front, so Stat,
+// Read and Seek never need another round trip to answer with them. A store
+// that omits ContentLength or LastModified from its HEAD response is
+// refused here rather than producing a File whose methods can't answer.
 func (f *BucketFS) OpenFile(ctx context.Context, name string) (fs.File, error) {
 	f.debugLog(ctx, "s3:openfile", "bucket", f.bucket, "name", name)
 	return openFile(ctx, f.client, f.bucket, name)

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -1082,7 +1082,7 @@ func TestCopyStrategy_Mock(t *testing.T) {
 		api := &sizedCopyAPI{S3API: base, size: -1}
 		fsys := s3.NewBucketFS(api, bucket)
 		_, err := fsys.Copy(ctx, "dst-file", "src-file")
-		be.Nonzero(t, err)
+		be.True(t, errors.Is(err, s3.ErrNoContentLength))
 		be.Equal(t, 0, api.CallCount("CopyObject"))
 	})
 }
@@ -2077,6 +2077,7 @@ func TestOpenNilHeadField_Mock(t *testing.T) {
 			f, err := fsys.OpenFile(ctx, obj.Key)
 			be.Zero(t, f)
 			isPathError(t, err)
+			be.True(t, errors.Is(err, s3.ErrNoContentLength))
 			// The object is there; the store just didn't say how big (or how
 			// recently modified) it is. A caller must not mistake that for a
 			// missing key.

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -2024,3 +2024,64 @@ func TestNotExistMapping_Mock(t *testing.T) {
 		be.NilErr(t, file.Close())
 	})
 }
+
+// nilHeadFieldAPI is the mock with chosen fields on HeadObject's response
+// nilled out, so a test can drive openFile's missing-ContentLength (or
+// missing-LastModified) guard without a store that actually omits the
+// header.
+type nilHeadFieldAPI struct {
+	*mock.S3API
+	nilContentLength bool
+	nilLastModified  bool
+}
+
+func (a *nilHeadFieldAPI) HeadObject(ctx context.Context, in *s3v2.HeadObjectInput,
+	opts ...func(*s3v2.Options)) (*s3v2.HeadObjectOutput, error) {
+	out, err := a.S3API.HeadObject(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if a.nilContentLength {
+		out.ContentLength = nil
+	}
+	if a.nilLastModified {
+		out.LastModified = nil
+	}
+	return out, nil
+}
+
+// TestOpenNilHeadField_Mock covers the openFile side of the nil-HEAD-field
+// guard: OpenFile refuses a HEAD response missing ContentLength or
+// LastModified instead of handing back a File whose Stat, Read or Seek would
+// nil-deref the first time they need the value.
+func TestOpenNilHeadField_Mock(t *testing.T) {
+	ctx := context.Background()
+	obj := &mock.Object{Key: "src-file", Body: []byte("some content"), LastModified: time.Now()}
+
+	for _, tc := range []struct {
+		desc             string
+		nilContentLength bool
+		nilLastModified  bool
+	}{
+		{"nil ContentLength", true, false},
+		{"nil LastModified", false, true},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			base := mock.New(bucket, obj)
+			api := &nilHeadFieldAPI{
+				S3API:            base,
+				nilContentLength: tc.nilContentLength,
+				nilLastModified:  tc.nilLastModified,
+			}
+			fsys := s3.NewBucketFS(api, bucket)
+			f, err := fsys.OpenFile(ctx, obj.Key)
+			be.Zero(t, f)
+			isPathError(t, err)
+			// The object is there; the store just didn't say how big (or how
+			// recently modified) it is. A caller must not mistake that for a
+			// missing key.
+			be.False(t, errors.Is(err, fs.ErrNotExist))
+			be.Equal(t, 0, api.CallCount("GetObject"))
+		})
+	}
+}

--- a/fs/s3/multicopy.go
+++ b/fs/s3/multicopy.go
@@ -55,7 +55,7 @@ func (c *MultiCopier) Copy(ctx context.Context, buck string, dst, src string, sr
 		}
 	}
 	if srcHead.ContentLength == nil {
-		err = pathErr("copy", src, errors.New("missing content length"))
+		err = pathErr("copy", src, errNoContentLength)
 		return
 	}
 	srcSize = *srcHead.ContentLength

--- a/fs/s3/multicopy.go
+++ b/fs/s3/multicopy.go
@@ -55,7 +55,7 @@ func (c *MultiCopier) Copy(ctx context.Context, buck string, dst, src string, sr
 		}
 	}
 	if srcHead.ContentLength == nil {
-		err = pathErr("copy", src, errNoContentLength)
+		err = pathErr("copy", src, ErrNoContentLength)
 		return
 	}
 	srcSize = *srcHead.ContentLength

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -46,6 +46,14 @@ const maxCopySize int64 = 5 * 1024 * megabyte
 // size below can change without silently sending an oversized delete.
 const maxDeleteBatch = 1000
 
+// errNoContentLength is returned when a HEAD response omits ContentLength.
+// The AWS SDK models the field as *int64 because it can be absent, and some
+// S3-compatible stores and reverse proxies do omit it. openFile, copy and
+// MultiCopier.Copy all need a size to proceed -- for Stat/Read/Seek and for
+// the copy strategy choice, respectively -- so each refuses rather than
+// carrying an unknown length forward.
+var errNoContentLength = errors.New("missing content length")
+
 var (
 	// these are variable because we need pass them as pointers
 	delim = "/"
@@ -69,12 +77,19 @@ func openFile(ctx context.Context, api OpenFileAPI, buck string, name string) (f
 		}
 		return nil, pathErr("open", name, err)
 	}
+	// A store may omit ContentLength (or LastModified) on a HEAD response;
+	// refusing here is better than a File whose Stat/Read/Seek nil-deref the
+	// first time they need the size.
+	if headOut.ContentLength == nil || headOut.LastModified == nil {
+		return nil, pathErr("open", name, errNoContentLength)
+	}
 	f := &s3File{
 		ctx:    ctx,
 		api:    api,
 		bucket: buck,
 		key:    name,
 		info:   headOut,
+		size:   *headOut.ContentLength,
 	}
 	return f, nil
 }
@@ -189,7 +204,7 @@ func copy(ctx context.Context, api CopyAPI, buck string, dst, src string, opts .
 	// A store may omit ContentLength on a HEAD response; refusing here is
 	// better than carrying an unknown size into a choice that depends on it.
 	if srcHead.ContentLength == nil {
-		return 0, pathErr("copy", src, errors.New("missing content length"))
+		return 0, pathErr("copy", src, errNoContentLength)
 	}
 	srcSize := *srcHead.ContentLength
 	if srcSize > maxCopySize {
@@ -404,13 +419,14 @@ type s3File struct {
 	key    string
 	body   io.ReadCloser
 	info   *s3.HeadObjectOutput
+	size   int64 // f.info.ContentLength, resolved and validated in openFile
 	offset int64 // current position in the file
 }
 
 func (f *s3File) Stat() (fs.FileInfo, error) {
 	return &iofsInfo{
 		name:    path.Base(f.key),
-		size:    *f.info.ContentLength,
+		size:    f.size,
 		mode:    fileMode,
 		modTime: *f.info.LastModified,
 		sys:     f.info,
@@ -418,7 +434,7 @@ func (f *s3File) Stat() (fs.FileInfo, error) {
 }
 
 func (f *s3File) Read(p []byte) (int, error) {
-	size := *f.info.ContentLength
+	size := f.size
 	if f.offset >= size {
 		return 0, io.EOF
 	}
@@ -460,7 +476,7 @@ func (f *s3File) Name() string {
 // Seeking invalidates any existing body reader, causing the next Read to
 // issue a new GetObject request with the appropriate Range header.
 func (f *s3File) Seek(offset int64, whence int) (int64, error) {
-	size := *f.info.ContentLength
+	size := f.size
 	var newOffset int64
 	switch whence {
 	case io.SeekStart:

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -46,13 +46,15 @@ const maxCopySize int64 = 5 * 1024 * megabyte
 // size below can change without silently sending an oversized delete.
 const maxDeleteBatch = 1000
 
-// errNoContentLength is returned when a HEAD response omits ContentLength.
-// The AWS SDK models the field as *int64 because it can be absent, and some
-// S3-compatible stores and reverse proxies do omit it. openFile, copy and
-// MultiCopier.Copy all need a size to proceed -- for Stat/Read/Seek and for
-// the copy strategy choice, respectively -- so each refuses rather than
-// carrying an unknown length forward.
-var errNoContentLength = errors.New("missing content length")
+// ErrNoContentLength is the error wrapped by [BucketFS.OpenFile],
+// [BucketFS.Copy] and [MultiCopier.Copy] when a HEAD response omits
+// ContentLength. The AWS SDK models the field as *int64 because it can be
+// absent, and some S3-compatible stores and reverse proxies do omit it.
+// Each of those callers needs a size to proceed -- for Stat/Read/Seek and
+// for the copy strategy choice, respectively -- so each refuses rather than
+// carrying an unknown length forward. A caller can check for it with
+// errors.Is.
+var ErrNoContentLength = errors.New("missing content length")
 
 var (
 	// these are variable because we need pass them as pointers
@@ -81,7 +83,7 @@ func openFile(ctx context.Context, api OpenFileAPI, buck string, name string) (f
 	// refusing here is better than a File whose Stat/Read/Seek nil-deref the
 	// first time they need the size.
 	if headOut.ContentLength == nil || headOut.LastModified == nil {
-		return nil, pathErr("open", name, errNoContentLength)
+		return nil, pathErr("open", name, ErrNoContentLength)
 	}
 	f := &s3File{
 		ctx:    ctx,
@@ -204,7 +206,7 @@ func copy(ctx context.Context, api CopyAPI, buck string, dst, src string, opts .
 	// A store may omit ContentLength on a HEAD response; refusing here is
 	// better than carrying an unknown size into a choice that depends on it.
 	if srcHead.ContentLength == nil {
-		return 0, pathErr("copy", src, errNoContentLength)
+		return 0, pathErr("copy", src, ErrNoContentLength)
 	}
 	srcSize := *srcHead.ContentLength
 	if srcSize > maxCopySize {


### PR DESCRIPTION
## Summary
This PR adds validation for required fields in S3 HEAD responses to prevent nil pointer dereferences. When a store or reverse proxy omits `ContentLength` or `LastModified` from a HEAD response, the code now refuses the operation early with a clear error rather than allowing a File or copy operation to proceed with incomplete metadata.

## Key Changes

- **New error type**: Introduced `ErrNoContentLength` as a sentinel error that wraps the specific case where a HEAD response is missing required fields. This allows callers to distinguish between "object not found" and "object exists but metadata is incomplete."

- **OpenFile validation**: Added a guard in `openFile()` that checks both `ContentLength` and `LastModified` are present before returning a File. This prevents `Stat()`, `Read()`, and `Seek()` from nil-dereferencing these fields.

- **Copy validation**: Updated both `copy()` and `MultiCopier.Copy()` to use the new `ErrNoContentLength` error when `ContentLength` is missing, replacing generic "missing content length" errors.

- **s3File optimization**: Added a `size` field to `s3File` that caches the resolved `ContentLength` value from the HEAD response. This eliminates repeated pointer dereferences in `Stat()`, `Read()`, and `Seek()` methods.

- **Documentation**: Enhanced doc comments in `fs.go` and `doc.go` to explain the validation behavior and why it's necessary.

- **Test coverage**: Added `TestOpenNilHeadField_Mock()` that verifies `OpenFile` correctly rejects HEAD responses with missing `ContentLength` or `LastModified`, ensuring the error is distinguishable from `fs.ErrNotExist`.

## Implementation Details

The validation happens at the boundary where metadata is first retrieved (in `openFile()` and `copy()`), ensuring that downstream code can safely dereference these fields without nil checks. The cached `size` field in `s3File` provides a minor performance benefit by avoiding repeated pointer dereferences during file operations.

https://claude.ai/code/session_01Rv9DZcvUFuCJHtdqAHjxCn