### PR TITLE
fs/s3: MultiCopier receiver mutation and MPU cleanup context

### DIFF
--- a/fs/s3/doc.go
+++ b/fs/s3/doc.go
@@ -58,6 +58,13 @@
 //     still reachable through errors.As. A missing bucket is deliberately not
 //     reported that way: it is a configuration error, not a missing file.
 //
+//   - [MultiCopier.Copy] aborts or completes its multipart upload on a
+//     context derived from the caller's, not the caller's context itself: if
+//     the caller cancels mid-copy, that cleanup request still needs to reach
+//     S3, or the upload's parts are orphaned until a lifecycle rule reaps
+//     them. The derived context keeps the caller's values but not its
+//     cancellation or deadline, under its own fixed timeout.
+//
 // # Compatibility
 //
 // The interfaces above are part of the API, so changing them breaks any

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -978,6 +978,50 @@ func TestMultiCopierSpecialCharacters_Mock(t *testing.T) {
 	be.Nonzero(t, api.PartCount())
 }
 
+// TestMultiCopierConcurrentReuse_Mock drives one MultiCopier, left at its
+// zero-value PartSize/Concurrency, through several concurrent Copy calls.
+// BucketFS shares a single set of copy options -- and so, in effect, a
+// single MultiCopier -- across every copy it makes, so two copies racing on
+// one MultiCopier is the shape production traffic actually takes. Before
+// this fix, Copy wrote its defaulted PartSize and Concurrency back onto the
+// receiver; run with -race, concurrent copies here reliably reported a
+// write/write race on both fields. The zero-value assertions below are the
+// deterministic half of the proof: they fail on the old code whether or not
+// -race is enabled, because some copy's defaulting always won the race and
+// left the receiver non-zero.
+func TestMultiCopierConcurrentReuse_Mock(t *testing.T) {
+	ctx := context.Background()
+	const srcSize = int64(6 * megabyte) // over the 5 MiB min part size, under the 32 MiB default: one part per copy
+	srcBody := mock.RandBytes(srcSize)
+	api := mock.New(bucket, &mock.Object{Key: "src-file", Body: srcBody})
+	copier := s3.NewMultiCopier(api)
+
+	const workers = 4
+	var wg sync.WaitGroup
+	errs := make([]error, workers)
+	sizes := make([]int64, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			dst := fmt.Sprintf("dst-file-%d", i)
+			sizes[i], errs[i] = copier.Copy(ctx, bucket, dst, "src-file")
+		}(i)
+	}
+	wg.Wait()
+
+	const defaultCopyPartSize = 32 * megabyte
+	expETag := mock.ETag(srcBody, defaultCopyPartSize)
+	for i := 0; i < workers; i++ {
+		be.NilErr(t, errs[i])
+		be.Equal(t, srcSize, sizes[i])
+		dst := fmt.Sprintf("dst-file-%d", i)
+		be.Equal(t, expETag, api.UpdatedETag(dst))
+	}
+	be.Equal(t, int64(0), copier.PartSize)
+	be.Equal(t, 0, copier.Concurrency)
+}
+
 // sizedCopyAPI is the mock with HeadObject's ContentLength overridden, so a
 // test can drive copy's size-based strategy choice for a source far larger
 // than anything actually worth allocating. UploadPartCopy and

--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -1022,6 +1022,106 @@ func TestMultiCopierConcurrentReuse_Mock(t *testing.T) {
 	be.Equal(t, 0, copier.Concurrency)
 }
 
+// cleanupCtxAPI wraps the mock to make MultiCopier.Copy's cleanup-context
+// fix observable. The mock ignores ctx entirely, so on its own it cannot
+// tell a canceled context from a live one; this wrapper is what makes that
+// distinction visible to a test.
+//
+// cancel is called from inside UploadPartCopy, simulating the caller giving
+// up on the copy while a part request is in flight -- the same point
+// grp.Wait would observe the cancellation from in production. failPart
+// controls which of Copy's two cleanup paths the cancellation lands on:
+// true fails the part (driving the abort path), false lets it succeed
+// (driving the complete path, with cancellation arriving just after).
+// AbortMultipartUpload and CompleteMultipartUpload each record the ctx.Err()
+// they were called with and refuse the request if it is non-nil, standing
+// in for a real client that fails a request made on a dead context. Before
+// the fix, both are called with ctx itself, so cancel having already fired
+// means their recorded ctx.Err() is non-nil and the request is refused; the
+// fix's derived cleanupCtx has no error, so cleanup proceeds and the mock's
+// normal handler sets the corresponding flag.
+type cleanupCtxAPI struct {
+	*mock.S3API
+	cancel   context.CancelFunc
+	failPart bool
+
+	mu              sync.Mutex
+	abortCtxErr     error
+	completeCtxErr  error
+	gotAbortCall    bool
+	gotCompleteCall bool
+}
+
+func (a *cleanupCtxAPI) UploadPartCopy(ctx context.Context, in *s3v2.UploadPartCopyInput,
+	opts ...func(*s3v2.Options)) (*s3v2.UploadPartCopyOutput, error) {
+	out, err := a.S3API.UploadPartCopy(ctx, in, opts...)
+	a.cancel()
+	if a.failPart {
+		return nil, context.Canceled
+	}
+	return out, err
+}
+
+func (a *cleanupCtxAPI) AbortMultipartUpload(ctx context.Context, in *s3v2.AbortMultipartUploadInput,
+	opts ...func(*s3v2.Options)) (*s3v2.AbortMultipartUploadOutput, error) {
+	a.mu.Lock()
+	a.gotAbortCall = true
+	a.abortCtxErr = ctx.Err()
+	a.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return a.S3API.AbortMultipartUpload(ctx, in, opts...)
+}
+
+func (a *cleanupCtxAPI) CompleteMultipartUpload(ctx context.Context, in *s3v2.CompleteMultipartUploadInput,
+	opts ...func(*s3v2.Options)) (*s3v2.CompleteMultipartUploadOutput, error) {
+	a.mu.Lock()
+	a.gotCompleteCall = true
+	a.completeCtxErr = ctx.Err()
+	a.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return a.S3API.CompleteMultipartUpload(ctx, in, opts...)
+}
+
+// TestMultiCopierCleanupContext_Mock covers both of Copy's cleanup paths --
+// abort and complete -- against a context the caller cancels while a part
+// copy is in flight. Before the fix, the deferred cleanup request ran on
+// that same canceled context and was refused, leaving the multipart upload
+// neither aborted nor completed: an orphan that S3 bills until a lifecycle
+// rule reaps it.
+func TestMultiCopierCleanupContext_Mock(t *testing.T) {
+	t.Run("abort survives caller cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		base := mock.New(bucket, &mock.Object{Key: "src-file", Body: []byte("some content")})
+		api := &cleanupCtxAPI{S3API: base, cancel: cancel, failPart: true}
+		copier := s3.NewMultiCopier(api)
+
+		_, err := copier.Copy(ctx, bucket, "dst-file", "src-file")
+		be.True(t, errors.Is(err, context.Canceled))
+		be.True(t, api.gotAbortCall)
+		be.True(t, api.MPUAbortedFlag())
+		be.NilErr(t, api.abortCtxErr)
+	})
+
+	t.Run("complete survives caller cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		base := mock.New(bucket, &mock.Object{Key: "src-file", Body: []byte("some content")})
+		api := &cleanupCtxAPI{S3API: base, cancel: cancel, failPart: false}
+		copier := s3.NewMultiCopier(api)
+
+		_, err := copier.Copy(ctx, bucket, "dst-file", "src-file")
+		be.NilErr(t, err)
+		be.True(t, api.gotCompleteCall)
+		be.True(t, api.MPUCompleteFlag())
+		be.NilErr(t, api.completeCtxErr)
+	})
+}
+
 // sizedCopyAPI is the mock with HeadObject's ContentLength overridden, so a
 // test can drive copy's size-based strategy choice for a source far larger
 // than anything actually worth allocating. UploadPartCopy and

--- a/fs/s3/multicopy.go
+++ b/fs/s3/multicopy.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -13,6 +14,12 @@ import (
 const (
 	defaultCopyPartConcurrency = 6
 	defaultCopyPartSize        = 32 * megabyte
+
+	// mpCleanupTimeout bounds the deferred AbortMultipartUpload or
+	// CompleteMultipartUpload request that follows a copy. It is not a
+	// budget for the copy itself -- it starts when cleanup runs, so a long
+	// copy does not eat into it.
+	mpCleanupTimeout = 30 * time.Second
 )
 
 type MultiCopier struct {
@@ -81,7 +88,19 @@ func (c *MultiCopier) Copy(ctx context.Context, buck string, dst, src string, sr
 		return
 	}
 	defer func() {
-		// complete or abort the multipart upload
+		// Complete or abort the multipart upload on a context that has
+		// survived ctx's cancellation. The case this exists for is exactly
+		// the one where ctx is already canceled: the caller gave up on the
+		// copy, grp.Wait returned ctx.Err(), and this defer runs to clean
+		// up. Using ctx here would carry that same cancellation into the
+		// cleanup request, which would then fail too -- leaving an orphaned
+		// multipart upload (parts uploaded, never aborted or completed)
+		// that S3 bills until a lifecycle rule reaps it. WithoutCancel keeps
+		// ctx's values (SDK middleware, logging) while dropping its
+		// cancellation and deadline; the fresh timeout bounds the cleanup
+		// request on its own.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), mpCleanupTimeout)
+		defer cleanupCancel()
 		switch {
 		case err != nil:
 			params := &s3.AbortMultipartUploadInput{
@@ -89,7 +108,7 @@ func (c *MultiCopier) Copy(ctx context.Context, buck string, dst, src string, sr
 				Key:      &dst,
 				UploadId: newUp.UploadId,
 			}
-			_, abortErr := c.api.AbortMultipartUpload(ctx, params)
+			_, abortErr := c.api.AbortMultipartUpload(cleanupCtx, params)
 			err = errors.Join(err, abortErr)
 		default:
 			upload := &types.CompletedMultipartUpload{
@@ -101,7 +120,7 @@ func (c *MultiCopier) Copy(ctx context.Context, buck string, dst, src string, sr
 				UploadId:        newUp.UploadId,
 				MultipartUpload: upload,
 			}
-			_, err = c.api.CompleteMultipartUpload(ctx, params)
+			_, err = c.api.CompleteMultipartUpload(cleanupCtx, params)
 		}
 	}()
 	grp, grpCtx := errgroup.WithContext(ctx)

--- a/fs/s3/multicopy.go
+++ b/fs/s3/multicopy.go
@@ -16,14 +16,14 @@ const (
 )
 
 type MultiCopier struct {
-	// PartSize sets the size of the object parts used
-	// for multipart object copy. If the part size is too
-	// small to be copied using the max number of parts,
-	// the part size will be increased in 1 MiB increments
-	// until it fits.
+	// PartSize sets the size of the object parts used for multipart object
+	// copy. If it is below the SDK's minimum upload part size, defaultCopyPartSize
+	// is used instead. If the resulting part size is too small to copy the
+	// object within the max number of parts, the part size is increased in 1
+	// MiB increments until it fits.
 	PartSize int64
-	// Concurrency stes the number of goroutines
-	// per copy for copying object parts. defaults to 12.
+	// Concurrency sets the number of goroutines per copy for copying object
+	// parts. Defaults to defaultCopyPartConcurrency (6) when less than 1.
 	Concurrency int
 
 	api MultiCopyAPI
@@ -41,6 +41,11 @@ func NewMultiCopier(api MultiCopyAPI, opts ...func(*MultiCopier)) *MultiCopier {
 	return &copier
 }
 
+// Copy copies the object at src to dst within buck using S3's multipart
+// UploadPartCopy API. PartSize and Concurrency are read from c but never
+// written back to it: Copy defaults an out-of-range value into a local for
+// the duration of the call, so one MultiCopier is safe to share and call
+// concurrently.
 func (c *MultiCopier) Copy(ctx context.Context, buck string, dst, src string, srcHeads ...*s3.HeadObjectOutput) (srcSize int64, err error) {
 	var srcHead *s3.HeadObjectOutput
 	if len(srcHeads) > 0 {
@@ -59,13 +64,15 @@ func (c *MultiCopier) Copy(ctx context.Context, buck string, dst, src string, sr
 		return
 	}
 	srcSize = *srcHead.ContentLength
-	if c.PartSize < manager.MinUploadPartSize {
-		c.PartSize = defaultCopyPartSize
+	partSize := c.PartSize
+	if partSize < manager.MinUploadPartSize {
+		partSize = defaultCopyPartSize
 	}
-	if c.Concurrency < 1 {
-		c.Concurrency = defaultCopyPartConcurrency
+	concurrency := c.Concurrency
+	if concurrency < 1 {
+		concurrency = defaultCopyPartConcurrency
 	}
-	psize, partCount := adjustPartSize(srcSize, c.PartSize, manager.MaxUploadParts)
+	psize, partCount := adjustPartSize(srcSize, partSize, manager.MaxUploadParts)
 	completedParts := make([]types.CompletedPart, partCount)
 	uploadParams := &s3.CreateMultipartUploadInput{Bucket: &buck, Key: &dst}
 	newUp, err := c.api.CreateMultipartUpload(ctx, uploadParams)
@@ -98,7 +105,7 @@ func (c *MultiCopier) Copy(ctx context.Context, buck string, dst, src string, sr
 		}
 	}()
 	grp, grpCtx := errgroup.WithContext(ctx)
-	grp.SetLimit(c.Concurrency)
+	grp.SetLimit(concurrency)
 	copySource := encodeCopySource(buck, src)
 	for i := range partCount {
 		grp.Go(func() error {


### PR DESCRIPTION
Addresses items 5 and 6 of [issue #167](https://github.com/srerickson/ocfl-go/issues/167) (items 1–4 are already on `main`). Both defects are in `fs/s3/multicopy.go`; each has its own commit.

## Summary

- **Item 5 — `MultiCopier.Copy` mutates its own receiver.** `Copy` wrote its defaulted `PartSize`/`Concurrency` back onto `c`. `BucketFS` hands the same options to every copy, so two concurrent `Copy` calls on one `MultiCopier` raced on both fields. Fixed by defaulting into locals and threading them through `adjustPartSize`/`grp.SetLimit` instead of writing back to the receiver.
- **Item 6 — the deferred MPU abort/complete ran on the caller's context.** If the caller canceled mid-copy, the deferred cleanup ran `AbortMultipartUpload`/`CompleteMultipartUpload` with that same canceled context, so the cleanup request failed too — orphaning the multipart upload (billed until a lifecycle rule reaps it). Fixed by running cleanup on `context.WithoutCancel(ctx)` under its own fixed timeout, started inside the defer so it doesn't eat into the copy's own budget.

I checked whether the AWS SDK for Go v2 already solves either of these before writing new code: `feature/s3/manager` and its successor `feature/s3/transfermanager` provide upload/download orchestration but no multipart-copy (`UploadPartCopy`) orchestration — that's still an open SDK feature request ([aws/aws-sdk-go-v2#2095](https://github.com/aws/aws-sdk-go-v2/issues/2095)). `transfermanager` did solve item 6's exact problem for uploads via `Options.FailTimeout`, but its default (`0`) reinstates the caller's-context bug, and its implementation uses `context.Background()` for the fresh context, which drops the caller's context values too. This PR uses `context.WithoutCancel` instead, which keeps those values and drops only the cancellation/deadline, and keeps the timeout as a fixed internal constant rather than a public knob a caller could misconfigure back into the bug.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...` (full suite, including `fs/s3`)
- [x] New tests reproduce and pin each defect: `TestMultiCopierConcurrentReuse_Mock` (fails under `-race` and on the deterministic zero-value assertions against the pre-fix code) and `TestMultiCopierCleanupContext_Mock` (both abort and complete sub-tests fail against the pre-fix code) — verified by reverting each fix locally and confirming the corresponding test fails, then restoring.
- [ ] `make s3-up && make s3-test && make s3-down` — the `OCFL_TEST_S3`-gated integration tests against MinIO were not run in this environment (no Docker); neither change is encoding- or endpoint-specific, so the mock coverage above should carry the weight, but flagging this gap for a maintainer to run if desired.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4LkzZCNGhtV7zWhJch5iQ)_