### PR TITLE
fs/s3: stamp FS inside walkFiles, drop the WalkFiles wrapper

### DIFF
--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -184,21 +184,16 @@ func sameClient(a, b S3API) bool {
 	return false
 }
 
+// WalkFiles returns an iterator over every object under dir, per
+// [ocflfs.FileWalker].
+//
+// Each yielded ref carries this BucketFS as its FS, so a caller can open the
+// file through the ref alone. Iteration stops as soon as the callback returns
+// false, and a listing failure is delivered as the pair's error element with
+// nothing yielded after it.
 func (f *BucketFS) WalkFiles(ctx context.Context, dir string) iter.Seq2[*ocflfs.FileRef, error] {
 	f.debugLog(ctx, "s3:walkfiles", "bucket", f.bucket, "prefix", dir)
-	files := walkFiles(ctx, f.client, f.bucket, dir)
-	// The values yielded by walkfiles don't include the FS, we need to
-	// add it here.
-	return func(yield func(*ocflfs.FileRef, error) bool) {
-		for file, err := range files {
-			if file != nil {
-				file.FS = f
-			}
-			if !yield(file, err) {
-				break
-			}
-		}
-	}
+	return walkFiles(ctx, f.client, f.bucket, dir, f)
 }
 
 type S3API interface {

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -365,8 +365,14 @@ func deleteErr(e types.Error) error {
 	return errors.New("delete failed, no reason reported")
 }
 
-// walkFiles returns an iterator that yields PathInfo for files in the dir
-func walkFiles(ctx context.Context, api FilesAPI, buck string, dir string) iter.Seq2[*ocflfs.FileRef, error] {
+// walkFiles returns an iterator that yields a *[ocflfs.FileRef] for every
+// object under dir. fsys is stamped onto each ref's FS field, so a caller can
+// open the file through the ref without carrying the backend around. It is a
+// parameter rather than something the caller patches in afterwards: a wrapper
+// that re-yields to set it would be a second implementation of this
+// iterator's early-termination and error semantics, free to drift from this
+// one.
+func walkFiles(ctx context.Context, api FilesAPI, buck string, dir string, fsys ocflfs.FS) iter.Seq2[*ocflfs.FileRef, error] {
 	return func(yield func(*ocflfs.FileRef, error) bool) {
 		const op = "list_files"
 		if !fs.ValidPath(dir) {
@@ -392,6 +398,7 @@ func walkFiles(ctx context.Context, api FilesAPI, buck string, dir string) iter.
 					refPath = strings.TrimPrefix(refPath, dir+"/")
 				}
 				info := &ocflfs.FileRef{
+					FS:      fsys,
 					BaseDir: dir,
 					Path:    refPath,
 					Info: &iofsInfo{


### PR DESCRIPTION
BucketFS.WalkFiles called walkFiles and then wrapped the returned
iterator in a second one whose only job was to assign FileRef.FS on the
way past. That wrapper was a second implementation of the walk contract
-- early termination and error delivery -- free to drift from the one in
the generic fs.fileWalk. The drift is not hypothetical: #179 fixed a
nil-deref in fs.fileWalk that this implementation could not have had,
and vice versa.

Pass the FS into walkFiles as an ocflfs.FS parameter and set it on the
FileRef literal, matching how fs.fileWalk builds its refs, then delete
the wrapper. The walk contract now has exactly one implementation per
backend.

No behavior change, so no new tests: imptest.TestWalkFiles already pins
the three properties this has to preserve -- every yield carries the
backend's own FS instance, iteration stops when the callback returns
false, and a listing failure is delivered as the pair's error element
with nothing yielded after it -- and runs against both backends.

The helper's doc comment was also stale; it described the yielded value
as PathInfo, a type the package no longer has.

Refs #168 (item 3).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019tnV7jAqK4c1w8otEmTeWd