### PR TITLE
fs/s3: refuse listing entries with nil object fields

### DIFF
--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -2230,3 +2230,182 @@ func TestOpenNilHeadField_Mock(t *testing.T) {
 		})
 	}
 }
+
+// nilListFieldAPI is the mock with chosen fields on ListObjectsV2's response
+// nilled out, so a test can drive the listers' nil-field guards without a
+// store that actually omits them. blank is a closure rather than a set of
+// flags because a listing needs per-entry selection -- one object mangled,
+// its siblings intact -- and has to reach CommonPrefixes as well as Contents.
+type nilListFieldAPI struct {
+	*mock.S3API
+	blank func(*s3v2.ListObjectsV2Output)
+}
+
+var _ s3.S3API = (*nilListFieldAPI)(nil)
+
+func (a *nilListFieldAPI) ListObjectsV2(ctx context.Context, in *s3v2.ListObjectsV2Input,
+	opts ...func(*s3v2.Options)) (*s3v2.ListObjectsV2Output, error) {
+	out, err := a.S3API.ListObjectsV2(ctx, in, opts...)
+	if err != nil || out == nil {
+		return out, err
+	}
+	a.blank(out)
+	return out, nil
+}
+
+// blankContents returns a mangle that nils one field on every object in the
+// listing, leaving common prefixes alone.
+func blankContents(field string) func(*s3v2.ListObjectsV2Output) {
+	return func(out *s3v2.ListObjectsV2Output) {
+		for i := range out.Contents {
+			switch field {
+			case "Key":
+				out.Contents[i].Key = nil
+			case "Size":
+				out.Contents[i].Size = nil
+			case "LastModified":
+				out.Contents[i].LastModified = nil
+			}
+		}
+	}
+}
+
+// TestWalkFilesNilListField_Mock covers the walkFiles half of the
+// nil-listing-field guard: a page describing an object without a Key, Size or
+// LastModified fails the walk instead of nil-dereferencing inside the
+// iterator, where a caller cannot recover it as an error.
+func TestWalkFilesNilListField_Mock(t *testing.T) {
+	ctx := context.Background()
+	objs := []*mock.Object{
+		{Key: "obj/a.txt", Body: []byte("a"), LastModified: time.Now()},
+		{Key: "obj/b.txt", Body: []byte("bb"), LastModified: time.Now()},
+		{Key: "obj/c.txt", Body: []byte("ccc"), LastModified: time.Now()},
+	}
+
+	for _, field := range []string{"Key", "Size", "LastModified"} {
+		t.Run("nil "+field, func(t *testing.T) {
+			api := &nilListFieldAPI{
+				S3API: mock.New(bucket, objs...),
+				blank: blankContents(field),
+			}
+			fsys := s3.NewBucketFS(api, bucket)
+
+			var files []*ocflfs.FileRef
+			var walkErr error
+			var yieldedAfterErr bool
+			for f, err := range fsys.WalkFiles(ctx, "obj") {
+				if walkErr != nil {
+					// The iterator must not yield anything after an error.
+					yieldedAfterErr = true
+				}
+				if err != nil {
+					walkErr = err
+					continue
+				}
+				be.Nonzero(t, f)
+				be.Nonzero(t, f.Info)
+				files = append(files, f)
+			}
+
+			be.False(t, yieldedAfterErr)
+			isPathError(t, walkErr)
+			be.True(t, errors.Is(walkErr, s3.ErrIncompleteListing))
+			// The objects are there; the store just described them badly. A
+			// caller must not read that as a missing prefix.
+			be.False(t, errors.Is(walkErr, fs.ErrNotExist))
+			be.Equal(t, 0, len(files))
+		})
+	}
+
+	// The control: with nothing blanked the same fixture walks cleanly, so
+	// the guard is not firing on well-formed input.
+	t.Run("intact listing walks", func(t *testing.T) {
+		api := &nilListFieldAPI{
+			S3API: mock.New(bucket, objs...),
+			blank: func(*s3v2.ListObjectsV2Output) {},
+		}
+		fsys := s3.NewBucketFS(api, bucket)
+		var files []*ocflfs.FileRef
+		for f, err := range fsys.WalkFiles(ctx, "obj") {
+			be.NilErr(t, err)
+			files = append(files, f)
+		}
+		be.Equal(t, 3, len(files))
+	})
+}
+
+// TestReadDirNilListField_Mock is the dirEntries half of the same guard. It
+// covers CommonPrefixes too, which walkFiles never sees: dirEntries is the
+// only lister that sets a Delimiter.
+func TestReadDirNilListField_Mock(t *testing.T) {
+	ctx := context.Background()
+	objs := []*mock.Object{
+		{Key: "d/a.txt", Body: []byte("a"), LastModified: time.Now()},
+		{Key: "d/z.txt", Body: []byte("zz"), LastModified: time.Now()},
+		{Key: "d/sub/child.txt", Body: []byte("c"), LastModified: time.Now()},
+	}
+
+	blankPrefixes := func(out *s3v2.ListObjectsV2Output) {
+		for i := range out.CommonPrefixes {
+			out.CommonPrefixes[i].Prefix = nil
+		}
+	}
+
+	for _, tc := range []struct {
+		desc  string
+		blank func(*s3v2.ListObjectsV2Output)
+	}{
+		{"nil Key", blankContents("Key")},
+		{"nil Size", blankContents("Size")},
+		{"nil LastModified", blankContents("LastModified")},
+		{"nil Prefix", blankPrefixes},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			api := &nilListFieldAPI{
+				S3API: mock.New(bucket, objs...),
+				blank: tc.blank,
+			}
+			fsys := s3.NewBucketFS(api, bucket)
+
+			var entries []fs.DirEntry
+			var readErr error
+			var yieldedAfterErr bool
+			for entry, err := range fsys.DirEntries(ctx, "d") {
+				if readErr != nil {
+					yieldedAfterErr = true
+				}
+				if err != nil {
+					readErr = err
+					// A nil entry must accompany the error, never a
+					// half-built one -- the append rewrite exists so the
+					// sort comparator can never see a nil DirEntry.
+					be.Zero(t, entry)
+					continue
+				}
+				be.Nonzero(t, entry)
+				entries = append(entries, entry)
+			}
+
+			be.False(t, yieldedAfterErr)
+			isPathError(t, readErr)
+			be.True(t, errors.Is(readErr, s3.ErrIncompleteListing))
+			be.False(t, errors.Is(readErr, fs.ErrNotExist))
+			be.Equal(t, 0, len(entries))
+		})
+	}
+
+	t.Run("intact listing reads", func(t *testing.T) {
+		api := &nilListFieldAPI{
+			S3API: mock.New(bucket, objs...),
+			blank: func(*s3v2.ListObjectsV2Output) {},
+		}
+		fsys := s3.NewBucketFS(api, bucket)
+		entries, err := ocflfs.ReadDir(ctx, fsys, "d")
+		be.NilErr(t, err)
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		be.AllEqual(t, []string{"a.txt", "sub", "z.txt"}, names)
+	})
+}

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -56,6 +56,21 @@ const maxDeleteBatch = 1000
 // errors.Is.
 var ErrNoContentLength = errors.New("missing content length")
 
+// ErrIncompleteListing is the error wrapped by [BucketFS.DirEntries] and
+// [BucketFS.WalkFiles] when a ListObjectsV2 page carries an entry missing a
+// field they need: an object's Key, Size or LastModified, or a common
+// prefix's Prefix. The AWS SDK models all four as pointers -- Size only
+// since service/s3 v1.43.0, which corrected the nullability of most S3
+// structure fields -- but a conforming store sends every one of them.
+//
+// The listers refuse rather than skipping the entry or substituting a zero
+// value. A skipped entry silently under-reports the bucket, and a nil Size
+// read as 0 is indistinguishable from a genuinely empty object; both are
+// wrong-but-plausible answers, which is worse in a listing that builds OCFL
+// manifests than a failure the caller can see. A caller can check for it
+// with errors.Is.
+var ErrIncompleteListing = errors.New("incomplete listing entry")
+
 var (
 	// these are variable because we need pass them as pointers
 	delim = "/"
@@ -128,21 +143,36 @@ func dirEntries(ctx context.Context, api ReadDirAPI, buck string, dir string) it
 				return
 			}
 			prefixHasContent = true
-			entries := make([]fs.DirEntry, numEntries)
-			for i, item := range list.CommonPrefixes {
-				entries[i] = &iofsInfo{
+			// A conforming store sets every field read below; the SDK
+			// models them as pointers because Smithy makes S3 structure
+			// members optional, not because S3 omits them. Refuse a page
+			// that leaves one unset rather than skipping the entry or
+			// reading it as a zero value: a listing that quietly loses an
+			// object, or reports a real one as empty, is a wrong answer a
+			// caller cannot detect. See [ErrIncompleteListing].
+			entries := make([]fs.DirEntry, 0, numEntries)
+			for _, item := range list.CommonPrefixes {
+				if item.Prefix == nil {
+					yield(nil, pathErr("readdir", dir, ErrIncompleteListing))
+					return
+				}
+				entries = append(entries, &iofsInfo{
 					name: path.Base(*item.Prefix),
 					mode: dirMode,
-				}
+				})
 			}
-			for i, item := range list.Contents {
-				entries[numDirs+i] = &iofsInfo{
+			for _, item := range list.Contents {
+				if item.Key == nil || item.Size == nil || item.LastModified == nil {
+					yield(nil, pathErr("readdir", dir, ErrIncompleteListing))
+					return
+				}
+				entries = append(entries, &iofsInfo{
 					name:    path.Base(*item.Key),
 					size:    *item.Size,
 					mode:    fileMode,
 					modTime: *item.LastModified,
 					//sys:     &item,
-				}
+				})
 			}
 			slices.SortFunc(entries, func(a, b fs.DirEntry) int {
 				return strings.Compare(a.Name(), b.Name())
@@ -393,6 +423,14 @@ func walkFiles(ctx context.Context, api FilesAPI, buck string, dir string, fsys 
 				return
 			}
 			for _, s3obj := range listPage.Contents {
+				// See [ErrIncompleteListing]: an entry the store described
+				// incompletely is refused, not skipped. Dropping it here
+				// would under-report the walk, and a walk is how OCFL
+				// enumerates content.
+				if s3obj.Key == nil || s3obj.Size == nil || s3obj.LastModified == nil {
+					yield(nil, pathErr(op, dir, ErrIncompleteListing))
+					return
+				}
 				refPath := *s3obj.Key
 				if dir != "." {
 					refPath = strings.TrimPrefix(refPath, dir+"/")


### PR DESCRIPTION
dirEntries and walkFiles dereferenced Contents[].Key, .Size and
.LastModified, and CommonPrefixes[].Prefix, unconditionally. An S3API
implementation that leaves one unset panicked inside the iterator, where
the caller cannot recover it as an error.

Guard all four and deliver the failure through the iterator's error
element as the new exported ErrIncompleteListing, alongside the existing
ErrNoContentLength.

This departs from the fix prescribed in issue #168 item 1 ("skip the
entry, use aws.ToInt64/aws.ToTime for the rest"), deliberately:

  - A listing is how OCFL builds manifests and drives validation.
    Silently omitting an entry yields a wrong-but-plausible result -- an
    under-reported walk, an inventory missing a file -- which is worse
    than a loud failure, not better.
  - aws.ToInt64 on a nil Size reports a large object as zero-length, and
    an empty object is a valid thing for a manifest to contain, so the
    corruption is undetectable downstream. openFile settled the same
    question the same way (ErrNoContentLength).
  - deleteKeys does skip a nil Key, but that precedent points the other
    way: skipping in a delete is conservative, declining to destroy what
    it cannot name. Skipping in a listing asserts the object does not
    exist.
  - The fields are absent only from a non-conforming store. They are
    pointers as a code-generation artifact: Key and LastModified because
    Smithy makes S3 structure members optional, Size only since
    service/s3 v1.43.0, which corrected the nullability of most S3
    structure fields. Something that should never happen is worth
    failing loudly on.

dirEntries builds its slice with append rather than index assignment, so
an early return cannot leave a nil fs.DirEntry for the sort comparator.

Tested with a nilListFieldAPI wrapper in the s3_test package, following
the existing nilHeadFieldAPI pattern; the shared mock is unchanged, since
it always populates these fields. Each of the seven nil cases panics
against the unguarded listers and returns an error against the guarded
ones.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GzCzwyByoR6mDuiGSgE1oy