### PR TITLE
Skip S3 directory placeholder keys in ReadDir and WalkFiles

### DIFF
--- a/fs/s3/fs_test.go
+++ b/fs/s3/fs_test.go
@@ -455,6 +455,33 @@ func TestReadDir_Mock(t *testing.T) {
 				be.True(t, state.HasExtensions())
 				be.Equal(t, 1, len(state.VersionDirs))
 			},
+		}, {
+			desc:   "skips directory placeholder keys",
+			bucket: bucket,
+			dir:    "dir",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket,
+					// The dir's own placeholder, created by the S3 console
+					// or AWS DataSync -- not something this package writes.
+					&mock.Object{Key: "dir/"},
+					&mock.Object{Key: "dir/file.txt"})
+			},
+			expect: func(t *testing.T, entries []fs.DirEntry, err error) {
+				be.NilErr(t, err)
+				be.Equal(t, 1, len(entries))
+				be.Equal(t, "file.txt", entries[0].Name())
+			},
+		}, {
+			desc:   "prefix with only a placeholder reads as empty, not missing",
+			bucket: bucket,
+			dir:    "dir",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket, &mock.Object{Key: "dir/"})
+			},
+			expect: func(t *testing.T, entries []fs.DirEntry, err error) {
+				be.NilErr(t, err)
+				be.Equal(t, 0, len(entries))
+			},
 		},
 	}
 	for i, tcase := range cases {
@@ -1393,6 +1420,46 @@ func TestWalkFiles_Mock(t *testing.T) {
 			bucket: bucket,
 			expect: func(t *testing.T, state *mock.S3API, files []*ocflfs.FileRef, err error) {
 				isInvalidPathError(t, err)
+			},
+		},
+		{
+			desc: "skips directory placeholder keys under a prefix",
+			dir:  "obj",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket,
+					// Placeholders a console or DataSync leaves behind, not
+					// something this package writes: the walked prefix's own
+					// marker, and one for a subdirectory.
+					&mock.Object{Key: "obj/"},
+					&mock.Object{Key: "obj/v1/"},
+					&mock.Object{Key: "obj/inventory.json"},
+					&mock.Object{Key: "obj/v1/contents/file.txt"},
+				)
+			},
+			bucket: bucket,
+			expect: func(t *testing.T, state *mock.S3API, files []*ocflfs.FileRef, err error) {
+				be.NilErr(t, err)
+				be.Equal(t, 2, len(files))
+				for _, f := range files {
+					be.True(t, fs.ValidPath(f.Path))
+					be.Nonzero(t, f.Path)
+				}
+			},
+		},
+		{
+			desc: "skips directory placeholder keys with no prefix",
+			dir:  ".",
+			mock: func(t *testing.T) *mock.S3API {
+				return mock.New(bucket,
+					&mock.Object{Key: "obj/"},
+					&mock.Object{Key: "obj/inventory.json"},
+				)
+			},
+			bucket: bucket,
+			expect: func(t *testing.T, state *mock.S3API, files []*ocflfs.FileRef, err error) {
+				be.NilErr(t, err)
+				be.Equal(t, 1, len(files))
+				be.Equal(t, "obj/inventory.json", files[0].FullPath())
 			},
 		},
 	}

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -111,6 +111,19 @@ func openFile(ctx context.Context, api OpenFileAPI, buck string, name string) (f
 	return f, nil
 }
 
+// isDirPlaceholder reports whether key is a directory marker rather than an
+// object this package can address: it ends in the listing delimiter, so
+// fs.ValidPath rejects it as a file path regardless of size. Nothing in this
+// package's write path (write, openFile) ever creates such a key -- but the
+// S3 console creates exactly one when a user makes a folder, and AWS
+// DataSync does the same when replicating a directory tree, so a bucket
+// used as an OCFL storage root can carry these before this package ever
+// touches it. A lister must not emit a path fs.ValidPath rejects, so this is
+// skipped rather than yielded as a phantom empty file.
+func isDirPlaceholder(key string) bool {
+	return strings.HasSuffix(key, delim)
+}
+
 func dirEntries(ctx context.Context, api ReadDirAPI, buck string, dir string) iter.Seq2[fs.DirEntry, error] {
 	return func(yield func(fs.DirEntry, error) bool) {
 		if !fs.ValidPath(dir) {
@@ -162,7 +175,20 @@ func dirEntries(ctx context.Context, api ReadDirAPI, buck string, dir string) it
 				})
 			}
 			for _, item := range list.Contents {
-				if item.Key == nil || item.Size == nil || item.LastModified == nil {
+				if item.Key == nil {
+					yield(nil, pathErr("readdir", dir, ErrIncompleteListing))
+					return
+				}
+				if isDirPlaceholder(*item.Key) {
+					// A directory marker, not a file: see [isDirPlaceholder].
+					// It still counts toward numEntries above, so a prefix
+					// holding only its own marker reads as an existing,
+					// empty directory rather than fs.ErrNotExist -- the same
+					// answer the local backend gives for a real empty
+					// directory.
+					continue
+				}
+				if item.Size == nil || item.LastModified == nil {
 					yield(nil, pathErr("readdir", dir, ErrIncompleteListing))
 					return
 				}
@@ -427,7 +453,17 @@ func walkFiles(ctx context.Context, api FilesAPI, buck string, dir string, fsys 
 				// incompletely is refused, not skipped. Dropping it here
 				// would under-report the walk, and a walk is how OCFL
 				// enumerates content.
-				if s3obj.Key == nil || s3obj.Size == nil || s3obj.LastModified == nil {
+				if s3obj.Key == nil {
+					yield(nil, pathErr(op, dir, ErrIncompleteListing))
+					return
+				}
+				if isDirPlaceholder(*s3obj.Key) {
+					// A directory marker, not a file: see [isDirPlaceholder].
+					// This also skips the walked prefix's own marker (dir/
+					// itself, when walking under prefix dir/).
+					continue
+				}
+				if s3obj.Size == nil || s3obj.LastModified == nil {
 					yield(nil, pathErr(op, dir, ErrIncompleteListing))
 					return
 				}


### PR DESCRIPTION
## Summary
This PR adds handling for S3 directory placeholder keys (objects ending with `/`) that are created by the S3 console and AWS DataSync when managing directory structures. These placeholders are now properly skipped during directory listing and file walking operations, preventing them from being treated as files.

## Key Changes
- Added `isDirPlaceholder()` helper function to identify directory marker keys that end with the listing delimiter (`/`)
- Updated `dirEntries()` to skip directory placeholders while preserving the distinction between empty directories (existing but empty) and non-existent directories
- Updated `walkFiles()` to skip directory placeholders during file enumeration, including the walked prefix's own marker
- Added comprehensive test cases for both `ReadDir` and `WalkFiles` to verify placeholder handling with and without prefixes

## Implementation Details
- Directory placeholders are identified by checking if a key ends with the delimiter (`/`), which makes them invalid file paths per `fs.ValidPath`
- Placeholders are skipped rather than yielded, but they still count toward determining if a prefix exists (so a prefix with only its own placeholder reads as an empty directory, not `fs.ErrNotExist`)
- The implementation distinguishes between incomplete listings (which are errors) and directory placeholders (which are silently skipped)
- This change is backward compatible as the package's write path never creates such keys; they only come from external S3 tools

https://claude.ai/code/session_01W3mKdYgBDWMGWJBQoxZmS8