### PR TITLE
fs/s3: read dir="." on an empty bucket as an empty directory

### DIFF
--- a/fs/internal/imptest/direntriesfs.go
+++ b/fs/internal/imptest/direntriesfs.go
@@ -29,10 +29,17 @@ import (
 //     entry, not enumerated.
 //   - entries are sorted, as [ocflfs.DirEntriesFS] documents, so callers may
 //     rely on the order without sorting defensively.
+//   - the root always exists. A prefix that matches nothing is a missing
+//     directory, but "." names the backend's root -- the bucket itself, on
+//     S3 -- which is empty rather than absent before anything is written.
 //
 // Unlike Remove and RemoveAll this entry point takes no knobs: the two
 // backends agree on every case here, including a missing directory, which S3
 // reports as fs.ErrNotExist rather than as an empty listing.
+//
+// fsys must be empty when the suite starts: the first subtest reads the root
+// before anything is seeded, which is what pins the empty-root case without
+// a fixture knob.
 func TestDirEntries(t *testing.T, fsys ocflfs.WriteFS) {
 	t.Helper()
 	ctx := context.Background()
@@ -40,20 +47,6 @@ func TestDirEntries(t *testing.T, fsys ocflfs.WriteFS) {
 	dirFS, ok := fsys.(ocflfs.DirEntriesFS)
 	if !ok {
 		t.Fatal("backend does not implement ocflfs.DirEntriesFS")
-	}
-
-	// A deliberately unsorted creation order, so a backend that happens to
-	// return insertion order fails the sorted-order assertion.
-	const base = "imptest-direntries"
-	for _, name := range []string{
-		base + "/zeta.txt",
-		base + "/alpha.txt",
-		base + "/sub/child.txt",
-		base + "/sub/deeper/grandchild.txt",
-		base + "/middle.txt",
-	} {
-		_, err := fsys.Write(ctx, name, strings.NewReader("x"))
-		be.NilErr(t, err)
 	}
 
 	collect := func(t *testing.T, dir string) ([]fs.DirEntry, error) {
@@ -78,6 +71,34 @@ func TestDirEntries(t *testing.T, fsys ocflfs.WriteFS) {
 			out = append(out, e.Name())
 		}
 		return out
+	}
+
+	// Runs before the fixture below is written, so it sees a genuinely empty
+	// backend. Both callers hand this suite a freshly-created FS, so the
+	// ordering is all it takes -- no fixture knob, unlike WalkFiles.ErrWalk.
+	t.Run("empty root yields an empty listing", func(t *testing.T) {
+		// The counterpart to the missing-directory case below, and the one
+		// place the flat backend must not apply that rule: a fresh bucket
+		// lists nothing, but "." names the bucket, which exists. A backend
+		// that reads its own empty root as fs.ErrNotExist reports a
+		// difference the interface does not document.
+		entries, err := collect(t, ".")
+		be.NilErr(t, err)
+		be.Equal(t, 0, len(entries))
+	})
+
+	// A deliberately unsorted creation order, so a backend that happens to
+	// return insertion order fails the sorted-order assertion.
+	const base = "imptest-direntries"
+	for _, name := range []string{
+		base + "/zeta.txt",
+		base + "/alpha.txt",
+		base + "/sub/child.txt",
+		base + "/sub/deeper/grandchild.txt",
+		base + "/middle.txt",
+	} {
+		_, err := fsys.Write(ctx, name, strings.NewReader("x"))
+		be.NilErr(t, err)
 	}
 
 	t.Run("yields base names one level deep, sorted", func(t *testing.T) {

--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -82,6 +82,13 @@ func (f *BucketFS) OpenFile(ctx context.Context, name string) (fs.File, error) {
 	return openFile(ctx, f.client, f.bucket, name)
 }
 
+// DirEntries lists the immediate children of dir, per [ocflfs.DirEntriesFS].
+//
+// Directories are reconstructed from key prefixes, so a prefix that matches
+// no object is reported as fs.ErrNotExist: an empty directory is not
+// something S3 can hold. The one exception is dir ".", which names the
+// bucket and exists whether or not it holds any objects -- an empty bucket
+// lists empty, as an empty root directory does on the local backend.
 func (f *BucketFS) DirEntries(ctx context.Context, dir string) iter.Seq2[fs.DirEntry, error] {
 	f.debugLog(ctx, "s3:readdir", "bucket", f.bucket, "name", dir)
 	return dirEntries(ctx, f.client, f.bucket, dir)

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -149,8 +149,21 @@ func dirEntries(ctx context.Context, api ReadDirAPI, buck string, dir string) it
 			numFiles := len(list.Contents)
 			numEntries := numDirs + numFiles
 			if numEntries == 0 {
-				if !prefixHasContent {
-					// treat prefix without objects as a missing directory
+				// "." names the bucket itself, which exists whether or not it
+				// holds any objects: a missing bucket surfaces as a
+				// ListObjectsV2 error above, never as an empty page. So an
+				// empty bucket reads as an existing, empty directory -- the
+				// same answer the local backend gives for an empty root.
+				//
+				// Below the root the answer is the opposite, and deliberately
+				// so rather than by oversight: a prefix exists only for as
+				// long as some key carries it, so S3 has nothing that can
+				// represent an empty directory, and reporting the prefix as
+				// missing is the closest faithful answer. Nothing in OCFL
+				// depends on the local backend's ability to hold an empty
+				// directory -- every version directory carries at least an
+				// inventory.json.
+				if dir != "." && !prefixHasContent {
 					yield(nil, pathErr("readdir", dir, fs.ErrNotExist))
 				}
 				return


### PR DESCRIPTION
dirEntries turned any zero-entry listing page into fs.ErrNotExist. That is
right for a general prefix -- a prefix exists only for as long as some key
carries it, so S3 has nothing that can represent an empty directory -- but
wrong for ".", which names the bucket. A bucket that is not there surfaces
as a ListObjectsV2 error, never as an empty page, so a fresh bucket
reported its own root as missing where the local backend reads an empty
root back as an empty listing.

Exempt "." from the rule and record both halves in a comment: the root
always exists, and the asymmetry below it is deliberate faithful emulation
rather than an oversight. Nothing in OCFL depends on an empty directory --
every version directory carries at least an inventory.json.

Pin the case in imptest.TestDirEntries, next to the missing-directory
subtest, so the rule and its exemption are asserted side by side for both
backends. It needs no options knob: it reads the root before the fixture is
seeded, and every caller already supplies a freshly-created empty FS.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BHQGRUTPZvPmhQPNQmSGhc