### PR TITLE
Fix partial directory listing error handling in DirEntries

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -30,9 +30,23 @@ type FS interface {
 // directory.
 type DirEntriesFS interface {
 	FS
-	// DirEntries returns an iterator that will yield an fs.DirEntry from the named
-	// directory or an error (not both). The entries should be yielded in sorted
-	// order. If an error is yielded, iteration terminates.
+	// DirEntries returns an iterator over the entries in the named directory.
+	// Each yielded pair carries an fs.DirEntry or an error, never both, and
+	// entries are yielded in sorted order.
+	//
+	// An error terminates iteration: nothing follows it. It does not
+	// invalidate the entries that came before it, however -- a listing that
+	// fails partway yields the entries it managed to read and then the
+	// error, so one sequence may hold both. This follows io/fs rather than
+	// departing from it: [io/fs.ReadDirFile] documents the same rule for
+	// ReadDir(-1) ("returns the DirEntry list read until that point and a
+	// non-nil error"), [os.ReadDir] repeats it, and [io/fs.WalkDir] walks
+	// the partial listing when its callback lets it.
+	//
+	// So the entries are real, but the listing they came from is incomplete,
+	// and only the caller knows whether an incomplete one is usable: a
+	// caller that needs the whole directory must discard what it received
+	// once an error arrives.
 	DirEntries(ctx context.Context, name string) iter.Seq2[fs.DirEntry, error]
 }
 
@@ -165,8 +179,9 @@ func DirEntries(ctx context.Context, fsys FS, name string) iter.Seq2[fs.DirEntry
 }
 
 // ReadDir calls DirEntries and collects all yielded directory entries in a
-// slice. If an error is encountered, the slice will included all entries read
-// up the point of the error.
+// slice. If an error is encountered, the slice includes all entries read up to
+// the point of the error, matching [os.ReadDir]: those entries are real, but
+// the listing is incomplete. See [DirEntriesFS].
 func ReadDir(ctx context.Context, fsys FS, name string) ([]fs.DirEntry, error) {
 	var entries []fs.DirEntry
 	for entry, err := range DirEntries(ctx, fsys, name) {
@@ -238,6 +253,15 @@ func StatFile(ctx context.Context, fsys FS, name string) (fs.FileInfo, error) {
 
 // WalkFiles checks if fsys is a FileWalker and calls its WalkFiles if it is. If
 // fsys isn't a FileWalker, dir is walked using [DirEntries].
+//
+// Errors are yielded as they are encountered, and a yielded error means the
+// walk is incomplete: some directory could not be listed, and a listing that
+// failed partway may have yielded files before its error (see [DirEntriesFS]).
+// Where iteration goes after an error is left to the implementation -- the
+// generic walk continues with the directories it can still read, as
+// [io/fs.WalkDir] does, while a backend's own WalkFiles may stop at the first
+// failure -- so a caller that needs a complete walk must treat any error as
+// invalidating the whole sequence rather than only the entry it arrived with.
 func WalkFiles(ctx context.Context, fsys FS, dir string) iter.Seq2[*FileRef, error] {
 	if walkFS, ok := fsys.(FileWalker); ok {
 		return walkFS.WalkFiles(ctx, dir)

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -34,19 +34,10 @@ type DirEntriesFS interface {
 	// Each yielded pair carries an fs.DirEntry or an error, never both, and
 	// entries are yielded in sorted order.
 	//
-	// An error terminates iteration: nothing follows it. It does not
-	// invalidate the entries that came before it, however -- a listing that
-	// fails partway yields the entries it managed to read and then the
-	// error, so one sequence may hold both. This follows io/fs rather than
-	// departing from it: [io/fs.ReadDirFile] documents the same rule for
-	// ReadDir(-1) ("returns the DirEntry list read until that point and a
-	// non-nil error"), [os.ReadDir] repeats it, and [io/fs.WalkDir] walks
-	// the partial listing when its callback lets it.
-	//
-	// So the entries are real, but the listing they came from is incomplete,
-	// and only the caller knows whether an incomplete one is usable: a
-	// caller that needs the whole directory must discard what it received
-	// once an error arrives.
+	// A listing that fails partway yields the entries it managed to read and
+	// then the error, matching [io/fs.ReadDir] in the standard library. A
+	// caller that needs a complete listing must discard the entries once an
+	// error arrives.
 	DirEntries(ctx context.Context, name string) iter.Seq2[fs.DirEntry, error]
 }
 
@@ -179,9 +170,8 @@ func DirEntries(ctx context.Context, fsys FS, name string) iter.Seq2[fs.DirEntry
 }
 
 // ReadDir calls DirEntries and collects all yielded directory entries in a
-// slice. If an error is encountered, the slice includes all entries read up to
-// the point of the error, matching [os.ReadDir]: those entries are real, but
-// the listing is incomplete. See [DirEntriesFS].
+// slice. If an error is encountered, the slice includes all entries read up
+// to the point of the error, matching [os.ReadDir].
 func ReadDir(ctx context.Context, fsys FS, name string) ([]fs.DirEntry, error) {
 	var entries []fs.DirEntry
 	for entry, err := range DirEntries(ctx, fsys, name) {
@@ -254,14 +244,8 @@ func StatFile(ctx context.Context, fsys FS, name string) (fs.FileInfo, error) {
 // WalkFiles checks if fsys is a FileWalker and calls its WalkFiles if it is. If
 // fsys isn't a FileWalker, dir is walked using [DirEntries].
 //
-// Errors are yielded as they are encountered, and a yielded error means the
-// walk is incomplete: some directory could not be listed, and a listing that
-// failed partway may have yielded files before its error (see [DirEntriesFS]).
-// Where iteration goes after an error is left to the implementation -- the
-// generic walk continues with the directories it can still read, as
-// [io/fs.WalkDir] does, while a backend's own WalkFiles may stop at the first
-// failure -- so a caller that needs a complete walk must treat any error as
-// invalidating the whole sequence rather than only the entry it arrived with.
+// A yielded error means the walk is incomplete, and may follow files from a
+// directory listing that failed partway (see [DirEntriesFS]).
 func WalkFiles(ctx context.Context, fsys FS, dir string) iter.Seq2[*FileRef, error] {
 	if walkFS, ok := fsys.(FileWalker); ok {
 		return walkFS.WalkFiles(ctx, dir)

--- a/fs/local/localfs.go
+++ b/fs/local/localfs.go
@@ -167,15 +167,38 @@ func (fsys *FS) DirEntries(ctx context.Context, name string) iter.Seq2[fs.DirEnt
 		// not implement ReadDirFS -- and os.DirFS does, sorting internally.
 		// Reading the handle directly skips both, so it is done explicitly.
 		entries, err := dir.ReadDir(-1)
+		// A partial read yields what it got and then the error, matching
+		// fs.ReadDir. Unlike root.Open's error above, the handle's ReadDir
+		// error carries the OS-level path (e.g. reading a regular file as a
+		// directory yields "readdirent <tmpdir>/blocked: not a directory"),
+		// so both Op and Path need rewriting to keep the storage root out of
+		// the error and match the name the caller passed in. Rewritten here,
+		// before the entries are yielded, so the ctx.Err() branch below can
+		// report it without re-doing the rewrite.
+		if err != nil {
+			var pathErr *fs.PathError
+			if errors.As(err, &pathErr) {
+				pathErr.Op = "readdir"
+				pathErr.Path = name
+			}
+		}
 		slices.SortFunc(entries, func(a, b fs.DirEntry) int {
 			return strings.Compare(a.Name(), b.Name())
 		})
 		for _, entry := range entries {
-			if err := ctx.Err(); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				// A pending ReadDir error must not be dropped just because
+				// cancellation is noticed first: join them so a caller
+				// matching either context.Canceled or the read failure with
+				// errors.Is still finds it.
+				cause := ctxErr
+				if err != nil {
+					cause = errors.Join(ctxErr, err)
+				}
 				yield(nil, &fs.PathError{
 					Op:   "readdir",
 					Path: name,
-					Err:  err,
+					Err:  cause,
 				})
 				return
 			}
@@ -183,18 +206,7 @@ func (fsys *FS) DirEntries(ctx context.Context, name string) iter.Seq2[fs.DirEnt
 				return
 			}
 		}
-		// A partial read yields what it got and then the error, matching
-		// fs.ReadDir. Unlike root.Open's error above, the handle's ReadDir
-		// error carries the OS-level path (e.g. reading a regular file as a
-		// directory yields "readdirent <tmpdir>/blocked: not a directory"),
-		// so both Op and Path need rewriting to keep the storage root out of
-		// the error and match the name the caller passed in.
 		if err != nil {
-			var pathErr *fs.PathError
-			if errors.As(err, &pathErr) {
-				pathErr.Op = "readdir"
-				pathErr.Path = name
-			}
 			yield(nil, err)
 		}
 	}

--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -90,11 +90,9 @@ func (f *BucketFS) OpenFile(ctx context.Context, name string) (fs.File, error) {
 // bucket and exists whether or not it holds any objects -- an empty bucket
 // lists empty, as an empty root directory does on the local backend.
 //
-// The listing is delivered a ListObjectsV2 page at a time (maxKeys per page),
-// so a directory of more than one page whose listing fails partway yields the
-// entries from the pages already fetched and then the error -- the same
-// entries-then-error shape [ocflfs.DirEntriesFS] documents, arrived at by
-// pagination rather than a single partial read.
+// The listing is paged (ListObjectsV2, maxKeys per page); a listing that
+// fails partway yields the entries already fetched and then the error,
+// matching [ocflfs.DirEntriesFS].
 func (f *BucketFS) DirEntries(ctx context.Context, dir string) iter.Seq2[fs.DirEntry, error] {
 	f.debugLog(ctx, "s3:readdir", "bucket", f.bucket, "name", dir)
 	return dirEntries(ctx, f.client, f.bucket, dir)

--- a/fs/s3/fs.go
+++ b/fs/s3/fs.go
@@ -89,6 +89,12 @@ func (f *BucketFS) OpenFile(ctx context.Context, name string) (fs.File, error) {
 // something S3 can hold. The one exception is dir ".", which names the
 // bucket and exists whether or not it holds any objects -- an empty bucket
 // lists empty, as an empty root directory does on the local backend.
+//
+// The listing is delivered a ListObjectsV2 page at a time (maxKeys per page),
+// so a directory of more than one page whose listing fails partway yields the
+// entries from the pages already fetched and then the error -- the same
+// entries-then-error shape [ocflfs.DirEntriesFS] documents, arrived at by
+// pagination rather than a single partial read.
 func (f *BucketFS) DirEntries(ctx context.Context, dir string) iter.Seq2[fs.DirEntry, error] {
 	f.debugLog(ctx, "s3:readdir", "bucket", f.bucket, "name", dir)
 	return dirEntries(ctx, f.client, f.bucket, dir)

--- a/fs/wrapfs.go
+++ b/fs/wrapfs.go
@@ -16,9 +16,8 @@ func DirFS(dir string) *WrapFS { return NewWrapFS(os.DirFS(dir)) }
 
 // WrapFS wraps an [io/fs.FS] and implements [DirEntriesFS].
 //
-// DirEntries follows [DirEntriesFS]: a listing that fails partway yields the
-// entries it read and then the error, since fs.ReadDir(fsys.FS, name) already
-// carries that shape from the wrapped FS.
+// A listing that fails partway yields the entries it read and then the
+// error, matching [io/fs.ReadDir] in the standard library.
 type WrapFS struct {
 	fs.FS
 }

--- a/fs/wrapfs.go
+++ b/fs/wrapfs.go
@@ -15,6 +15,10 @@ func NewWrapFS(fsys fs.FS) *WrapFS { return &WrapFS{FS: fsys} }
 func DirFS(dir string) *WrapFS { return NewWrapFS(os.DirFS(dir)) }
 
 // WrapFS wraps an [io/fs.FS] and implements [DirEntriesFS].
+//
+// DirEntries follows [DirEntriesFS]: a listing that fails partway yields the
+// entries it read and then the error, since fs.ReadDir(fsys.FS, name) already
+// carries that shape from the wrapped FS.
 type WrapFS struct {
 	fs.FS
 }
@@ -60,11 +64,19 @@ func (fsys *WrapFS) DirEntries(ctx context.Context, name string) iter.Seq2[fs.Di
 		}
 		entries, err := fs.ReadDir(fsys.FS, name)
 		for _, entry := range entries {
-			if err := ctx.Err(); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				// A pending ReadDir error must not be dropped just because
+				// cancellation is noticed first: join them so a caller
+				// matching either context.Canceled or the read failure with
+				// errors.Is still finds it.
+				cause := ctxErr
+				if err != nil {
+					cause = errors.Join(ctxErr, err)
+				}
 				yield(nil, &fs.PathError{
 					Op:   "readdir",
 					Path: name,
-					Err:  err,
+					Err:  cause,
 				})
 				return
 			}

--- a/fs/wrapfs_test.go
+++ b/fs/wrapfs_test.go
@@ -1,1 +1,168 @@
 package fs_test
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/carlmjohnson/be"
+	ocflfs "github.com/srerickson/ocfl-go/fs"
+)
+
+// fakeDirEntry is a minimal fs.DirEntry, just enough to be told apart by
+// name.
+type fakeDirEntry struct{ name string }
+
+func (e fakeDirEntry) Name() string               { return e.name }
+func (e fakeDirEntry) IsDir() bool                { return false }
+func (e fakeDirEntry) Type() fs.FileMode          { return 0 }
+func (e fakeDirEntry) Info() (fs.FileInfo, error) { return nil, fs.ErrInvalid }
+
+// partialReadDirFile is an fs.ReadDirFile whose ReadDir(-1) call returns a
+// fixed slice of entries and a fixed error together, reproducing the
+// partial-listing shape [io/fs.ReadDirFile] documents for a real directory
+// handle that fails partway through a read. It does not implement
+// fs.ReadDirFS at the containing FS level, so fs.ReadDir reaches it through
+// Open + ReadDir(-1) -- the same path WrapFS.DirEntries takes for any wrapped
+// fs.FS that isn't itself a ReadDirFS (os.DirFS is; this fake deliberately
+// isn't, to exercise the fallback).
+type partialReadDirFile struct {
+	entries []fs.DirEntry
+	err     error
+}
+
+func (f *partialReadDirFile) Stat() (fs.FileInfo, error) { return nil, fs.ErrInvalid }
+func (f *partialReadDirFile) Read([]byte) (int, error)   { return 0, fs.ErrInvalid }
+func (f *partialReadDirFile) Close() error               { return nil }
+func (f *partialReadDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	return f.entries, f.err
+}
+
+var _ fs.ReadDirFile = (*partialReadDirFile)(nil)
+
+// partialReadDirFS opens dirFile for any name, standing in for a wrapped
+// fs.FS whose one directory of interest fails partway through a listing.
+type partialReadDirFS struct {
+	dirFile *partialReadDirFile
+}
+
+func (f *partialReadDirFS) Open(string) (fs.File, error) { return f.dirFile, nil }
+
+var _ fs.FS = (*partialReadDirFS)(nil)
+
+func namesOf(entries []fs.DirEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}
+
+// collectDirEntries drains a DirEntries iterator, returning every entry
+// yielded and the first error, mirroring how ocflfs.ReadDir consumes it.
+func collectDirEntries(seq func(func(fs.DirEntry, error) bool)) ([]fs.DirEntry, error) {
+	var entries []fs.DirEntry
+	var err error
+	for entry, e := range seq {
+		if entry != nil {
+			entries = append(entries, entry)
+		}
+		if e != nil {
+			err = e
+			break
+		}
+	}
+	return entries, err
+}
+
+func TestWrapFSDirEntriesPartialListing(t *testing.T) {
+	// The defect reported in issue 176: a wrapped fs.FS whose ReadDir(-1)
+	// returns entries and an error together used to have those entries
+	// yielded first and the error last, in the same sequence -- which is
+	// exactly what DirEntriesFS now documents as the expected shape (see
+	// fs/fs.go), not a bug. This pins the sequence exactly: the entries, in
+	// order, then the one error, then nothing further.
+	readErr := errors.New("read failed partway")
+	fsys := ocflfs.NewWrapFS(&partialReadDirFS{
+		dirFile: &partialReadDirFile{
+			entries: []fs.DirEntry{fakeDirEntry{"a"}, fakeDirEntry{"b"}},
+			err:     readErr,
+		},
+	})
+
+	entries, err := collectDirEntries(fsys.DirEntries(context.Background(), "dir"))
+	be.AllEqual(t, []string{"a", "b"}, namesOf(entries))
+	// WrapFS yields whatever fs.ReadDir returns as the terminal error
+	// verbatim -- it wraps in *fs.PathError only where it constructs the
+	// error itself (invalid path, cancellation below), not this tail case.
+	be.Equal(t, readErr, err)
+}
+
+func TestWrapFSDirEntriesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	t.Run("during a listing with no read error", func(t *testing.T) {
+		fsys := ocflfs.NewWrapFS(&partialReadDirFS{
+			dirFile: &partialReadDirFile{
+				entries: []fs.DirEntry{fakeDirEntry{"a"}},
+			},
+		})
+		entries, err := collectDirEntries(fsys.DirEntries(ctx, "dir"))
+		be.Equal(t, 0, len(entries))
+		be.True(t, errors.Is(err, context.Canceled))
+
+		var pathErr *fs.PathError
+		be.True(t, errors.As(err, &pathErr))
+		be.Equal(t, "readdir", pathErr.Op)
+		be.Equal(t, "dir", pathErr.Path)
+		// Nothing else is joined in: the cause is exactly context.Canceled.
+		be.Equal(t, context.Canceled, pathErr.Err)
+	})
+
+	t.Run("during a failed listing, both errors survive", func(t *testing.T) {
+		// A canceled context must not shadow a pending ReadDir error: a
+		// caller matching either context.Canceled or the read failure with
+		// errors.Is should find it. This is the secondary defect named in
+		// issue 176.
+		readErr := errors.New("read failed partway")
+		fsys := ocflfs.NewWrapFS(&partialReadDirFS{
+			dirFile: &partialReadDirFile{
+				entries: []fs.DirEntry{fakeDirEntry{"a"}},
+				err:     readErr,
+			},
+		})
+		entries, err := collectDirEntries(fsys.DirEntries(ctx, "dir"))
+		be.Equal(t, 0, len(entries))
+		be.True(t, errors.Is(err, context.Canceled))
+		be.True(t, errors.Is(err, readErr))
+	})
+}
+
+func TestWrapFSDirEntriesInvalidPath(t *testing.T) {
+	fsys := ocflfs.NewWrapFS(&partialReadDirFS{dirFile: &partialReadDirFile{}})
+	for _, dir := range []string{"../escape", "/absolute", "a/../b", ""} {
+		_, err := collectDirEntries(fsys.DirEntries(context.Background(), dir))
+		be.True(t, err != nil)
+		be.True(t, errors.Is(err, fs.ErrInvalid))
+	}
+}
+
+func TestWrapFSDirEntriesHappyPath(t *testing.T) {
+	// The real os.DirFS route: os.DirFS implements fs.ReadDirFS, so
+	// fs.ReadDir(fsys.FS, name) takes the single-call path instead of the
+	// Open+ReadDir(-1) fallback the fakes above exercise. Sorted order and a
+	// clean, error-free listing are asserted here.
+	dir := t.TempDir()
+	for _, name := range []string{"zeta.txt", "alpha.txt"} {
+		be.NilErr(t, os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644))
+	}
+	fsys := ocflfs.DirFS(dir)
+
+	entries, err := collectDirEntries(fsys.DirEntries(context.Background(), "."))
+	be.NilErr(t, err)
+	be.AllEqual(t, []string{"alpha.txt", "zeta.txt"}, namesOf(entries))
+}


### PR DESCRIPTION
## Summary

This PR fixes #176: error handling in directory listing operations to properly preserve errors that occur during partial reads, especially when context cancellation happens concurrently with a read failure.

## Key Changes

- **WrapFS and localfs DirEntries**: When context cancellation is detected during iteration, any pending ReadDir error is now joined with the cancellation error using `errors.Join()` rather than being silently dropped. This ensures callers can detect both the cancellation and the underlying read failure.

- **Error rewriting in localfs**: Moved the ReadDir error rewriting (Op and Path fields) to occur before entries are yielded, so the context cancellation branch can use the already-rewritten error without duplication.

- **Documentation updates**: 
  - Updated `DirEntriesFS` interface documentation to explicitly document that partial reads yield entries followed by an error, matching `io/fs.ReadDir` behavior
  - Added clarifications to `ReadDir`, `WalkFiles`, and `DirEntries` functions about partial listing semantics
  - Added documentation to `WrapFS` and S3 `BucketFS.DirEntries` about partial listing behavior

- **Comprehensive test coverage**: Added `wrapfs_test.go` with tests covering:
  - Partial listings with errors (entries yielded before error)
  - Context cancellation during clean listings
  - Context cancellation during failed listings (both errors preserved)
  - Invalid path validation
  - Happy path with real `os.DirFS`

## Implementation Details

The fix ensures that when both a ReadDir error and context cancellation occur, the error chain preserves both failures so that `errors.Is()` checks for either `context.Canceled` or the underlying read error will succeed. This matches the principle that cancellation should not silently drop other errors that occurred during the operation.
